### PR TITLE
Special handling for Kafka's retryable exceptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2020-07-09
+### Added
+* Special handling for Kafka's retryable exceptions.
+
 ## [0.1.2] - 2020-07-08
 ### Changed
 * `tw_tkms_proxy_cycle` metric has `pollResult` tag, which indicates if it was "an empty cycle" or not.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,7 +3,7 @@
 The tests are important.
 
 The library has extensive automatic tests coverage, but more will never hurt. However, avoid high maintenance (unit) tests, try to write tests
-without mocking anything and rely on internal components or their relation.
+without mocking anything and do not rely on internal components nor their relation.
 
 ## ComplexTest
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.1.2
+version=0.1.3

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/ITkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/ITkmsDao.java
@@ -25,7 +25,7 @@ public interface ITkmsDao {
 
   List<MessageRecord> getMessages(TkmsShardPartition shardPartition, int maxCount);
 
-  void deleteMessage(TkmsShardPartition shardPartition, List<Long> records);
+  void deleteMessages(TkmsShardPartition shardPartition, List<Long> records);
 
   @Data
   @Accessors(chain = true)

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
@@ -293,7 +293,7 @@ public class TkmsDao implements ITkmsDao {
   }
 
   @Override
-  public void deleteMessage(TkmsShardPartition shardPartition, List<Long> ids) {
+  public void deleteMessages(TkmsShardPartition shardPartition, List<Long> ids) {
     MutableInt idIdx = new MutableInt();
     while (idIdx.getValue() < ids.size()) {
       for (int batchSize : batchSizes) {


### PR DESCRIPTION
We are logging retryable exceptions down via a rate limiter, about 2 exceptions in a second.

We would want to avoid errors spam when for example Kafka cluster is upgraded, but we don't want to go full silent mode as well - otherwise what if something gets retried for-ever? 