### PR TITLE
Efficient Snappy compression is the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2020-11-09
+### Changed
+* Default compression algorithm is Snappy.
+Only upgrade from 0.5.0 is supported.
+Upgrading directly from older version creates a processing pause until all service nodes have the new version running.
+
 ## [0.5.0] - 2020-11-06
 ### Removed
 * Gzip decompressor.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.5.0
+version=0.6.0

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -274,7 +274,7 @@ public class TkmsProperties {
     
     // For backward compatibility with 0.4, we can not set SNAPPY as default yet.
     // We will do that in 0.6.
-    private Algorithm algorithm = Algorithm.SNAPPY_FRAMED;
+    private Algorithm algorithm = Algorithm.SNAPPY;
 
     /**
      * Can be quite large, even when we have small(er) messages, because we reuse memory buffers.


### PR DESCRIPTION
## Context

In last version we used snappy framed compression as default, to be backward compatible with 0.4
But snappy framed compression still has too high memory allocation rate.

### Changes

Set snappy as default compression algorithm.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
