### PR TITLE
Error when registering metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2020-12-17
+### Fixed
+* Registering a metric for failed kafka send resulted in error because of wrong set of tags being used. 
+
 ## [0.6.1] - 2020-11-13
 ### Fixed
 * Control was not always yielded for proxy leader.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.6.1
+version=0.6.2

--- a/tw-tkms-starter/build.gradle
+++ b/tw-tkms-starter/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
     runtimeOnly libraries.twGracefulShutdown
     runtimeOnly libraries.twLeaderSelectorStarter
+    runtimeOnly libraries.micrometerRegistryPrometheus
 
     testCompileOnly libraries.spotbugsAnnotations
 

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
@@ -129,7 +129,8 @@ public class TkmsMetricsTemplate implements ITkmsMetricsTemplate {
         .counter(PROXY_MESSAGE_SEND, Tags.of(
             partitionTag(shardPartition),
             shardTag(shardPartition),
-            successTag(false)))
+            successTag(false),
+            topicTag(topic)))
         .increment();
   }
 

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MetricsTemplateIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MetricsTemplateIntTest.java
@@ -1,0 +1,21 @@
+package com.transferwise.kafka.tkms;
+
+import com.transferwise.kafka.tkms.api.TkmsShardPartition;
+import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
+import com.transferwise.kafka.tkms.test.BaseIntTest;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class MetricsTemplateIntTest extends BaseIntTest {
+
+  @Autowired
+  private ITkmsMetricsTemplate metricsTemplate;
+
+  // Production bug coverage
+  @Test
+  void proxyMessageSendFailureAfterSuccessCanBeRegistered() {
+    metricsTemplate.recordProxyMessageSendSuccess(TkmsShardPartition.of(0, 0), "Topic", Instant.now());
+    metricsTemplate.recordProxyMessageSendFailure(TkmsShardPartition.of(0, 0), "Topic");
+  }
+}


### PR DESCRIPTION
## Context

Bug, https://rollbar.com/TransferWise/public/items/240788/

### Changes

Registering a metric for failed kafka send resulted in error because of wrong set of tags being used.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
