### PR TITLE
Keep the default compression algorithm Snappy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.3] - 2021-01-03
+### Changed
+* Keep the default compression algorithm Snappy, to allow seemless upgrade from 0.6.x
+
 ## [0.7.2] - 2020-12-21
 ### Fixed
 * Custom data source providers need to extend ITkmsDataSourceProvider interface instead of concrete class

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.7.2
+version=0.7.3

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -284,7 +284,7 @@ public class TkmsProperties {
       }
     }
     
-    private Algorithm algorithm = Algorithm.LZ4;
+    private Algorithm algorithm = Algorithm.SNAPPY;
 
     /**
      * Can be quite large, even when we have small(er) messages, because we reuse memory buffers.


### PR DESCRIPTION

## Context

Upgrades.

### Changes

Keep the default compression algorithm Snappy, to allow seamless upgrade from 0.6.x.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
