### PR TITLE
Buckets count for metric `tw_tkms_dao_poll_all_results_count` are now correctly bounded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2021-02-12
+### Fixed
+Buckets count for metric `tw_tkms_dao_poll_all_results_count` are now correctly bounded.
+
 ## [0.9.0] - 2021-02-10
 ### Changed
 * Message interceptors are now able to do batch processing.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.9.0
+version=0.9.1

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
@@ -74,6 +74,7 @@ public class TkmsMetricsTemplate implements ITkmsMetricsTemplate {
     slos.put(PROXY_KAFKA_MESSAGES_SEND, defaultSlos);
     slos.put(PROXY_MESSAGES_DELETION, defaultSlos);
     slos.put(STORED_MESSAGE_PARSING, defaultSlos);
+    slos.put(DAO_POLL_ALL_RESULTS_COUNT, defaultSlos);
     slos.put(MESSAGE_INSERT_TO_ACK, new double[]{1, 5, 25, 125, 625, 3125, 3125 * 5});
     slos.put(COMPRESSION_RATIO_ACHIEVED, new double[]{0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.25, 2});
 


### PR DESCRIPTION
## Context

Metrics

### Changes

Buckets count for metric `tw_tkms_dao_poll_all_results_count` are now correctly bounded.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
