### PR TITLE
Removed redundant configuration parameter of `useCompression`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2021-03-16
+### Changed.
+* Removed redundant configuration parameter of `useCompression`.
+
 ## [0.10.0] - 2021-03-01
 ### Changed
 * Default polling timeout was increased from 10 ms to 25 ms.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.10.0
+version=0.11.0

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -122,15 +122,6 @@ public class TkmsProperties {
   private Duration proxyTimeToLive = Duration.ofMinutes(10);
 
   /**
-   * Is message compression enabled.
-   *
-   * <p>By default the message compression is enabled as we are optimizing for network and database IO.
-   * Only conceivable downside is that there will be no meaningful way for DBAs to search specific messages in the database, But on the other hand,
-   * there should be no need for that, those messages are just so short-living in the storage anyway.
-   */
-  private boolean useCompression = true;
-
-  /**
    * Safety net for validating message sizes before registering them with tw-tkms.
    *
    * <p>Be extra careful here by validating what is the corresponding value on the Kafka server side.


### PR DESCRIPTION
## Context

Configuration.

### Changes

Removed redundant configuration parameter of `useCompression`.

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
