### PR TITLE
Support for long running transactions in Postgres.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.0] - 2021-05-31
 ### Changed
-* Handling a case, where Postgres database has long running transactions preventing dead tuples being cleared for tw-tkms tables.
+* Handling a case, where Postgres database has long running transactions, and those are preventing dead tuples being cleared for tw-tkms tables,
+  resulting in massive tw-tkms slow down and database overload. 
   More detailed info [here](docs/postgres_with_long_transactions.md).
 
 ## [0.13.0] - 2021-05-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2021-05-31
+### Changed
+* Handling a case, where Postgres database has long running transactions preventing dead tuples being cleared for tw-tkms tables.
+  More detailed info [here](docs/postgres_with_long_transactions.md).
+
 ## [0.13.0] - 2021-05-31
 ### Changed
 * JDK 11+ is required

--- a/TODO.md
+++ b/TODO.md
@@ -4,8 +4,5 @@
 
 3. Avoid engineers creating tables manually. Provide at least Flyway auto configuration.
 
-4. Validate innodb and postgres table statistics at the start. Too many engineers have forgotten to set those correctly by docs whileas this is utmost
-   important for performance.
-
 5. Add hierarchical Valid annotations for TkmsProperties.
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,3 +4,8 @@
 
 3. Avoid engineers creating tables manually. Provide at least Flyway auto configuration.
 
+4. Validate innodb and postgres table statistics at the start. Too many engineers have forgotten to set those correctly by docs whileas this is utmost
+   important for performance.
+
+5. Add hierarchical Valid annotations for TkmsProperties.
+

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,18 +1,18 @@
 ext {
-    protobufVersion = "3.17.1"
+    protobufVersion = "3.18.0"
     libraries = [
             // version defined
             awaitility                      : 'org.awaitility:awaitility:4.1.0',
-            commonsIo                       : 'commons-io:commons-io:2.9.0',
-            curatorFramework                : 'org.apache.curator:curator-framework:5.1.0',
-            curatorRecipes                  : 'org.apache.curator:curator-recipes:5.1.0',
+            commonsIo                       : 'commons-io:commons-io:2.11.0', // TODO: Try to remove, we have JDK 11 requirement now
+            curatorFramework                : 'org.apache.curator:curator-framework:5.2.0',
+            curatorRecipes                  : 'org.apache.curator:curator-recipes:5.2.0',
             guava                           : 'com.google.guava:guava:30.1.1-jre',
             kafkaStreams                    : 'org.apache.kafka:kafka-streams:2.6.2',
             protobufJava                    : "com.google.protobuf:protobuf-java:${protobufVersion}",
             semver4j                        : "com.vdurmont:semver4j:3.1.0",
-            spotbugsAnnotations             : 'com.github.spotbugs:spotbugs-annotations:4.2.3',
-            springBootDependencies          : 'org.springframework.boot:spring-boot-dependencies:2.3.11.RELEASE',
-            twBaseUtils                     : 'com.transferwise.common:tw-base-utils:1.5.0',
+            spotbugsAnnotations             : 'com.github.spotbugs:spotbugs-annotations:4.4.1',
+            springBootDependencies          : 'org.springframework.boot:spring-boot-dependencies:2.4.11',
+            twBaseUtils                     : 'com.transferwise.common:tw-base-utils:1.6.0',
             twContext                       : 'com.transferwise.common:tw-context:0.11.0',
             twContextStarter                : 'com.transferwise.common:tw-context-starter:0.11.0',
             twGracefulShutdown              : 'com.transferwise.common:tw-graceful-shutdown:2.3.0',

--- a/demoapp/docker/docker-compose.yml
+++ b/demoapp/docker/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       KAFKA_JVM_PERFORMANCE_OPTS: -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -noverify -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
 #      KAFKA_CREATE_TOPICS: "MyTopic:10:1"
   mariadb:
-    image: mariadb:10.3
+    image: mariadb:10.4
     hostname: mysql
     ports:
       - "13306:3306"
@@ -60,9 +60,7 @@ services:
     --innodb_sync_array_size=16
     --innodb_log_file_size=10g
     --query_cache_type=0
-    --innodb_adaptive_hash_index=0
-    --binlog_commit_wait_count=10
-    --binlog_commit_wait_usec=1000000"
+    --innodb_adaptive_hash_index=0"
 
   #    --innodb_flush_log_at_trx_commit=1 --innodb_flush_method=O_DIRECT_NO_FSYNC
 

--- a/demoapp/src/main/java/com/transferwise/kafka/tkms/demoapp/MessagesListener.java
+++ b/demoapp/src/main/java/com/transferwise/kafka/tkms/demoapp/MessagesListener.java
@@ -20,7 +20,7 @@ public class MessagesListener {
 
   @Autowired
   private PaceTracker paceTracker;
-  
+
   @KafkaListener(topics = "MyTopic", containerFactory = "kafkaListenerContainerFactory")
   @SneakyThrows
   public void listen(List<ConsumerRecord<String, byte[]>> consumerRecords) {

--- a/demoapp/src/main/java/com/transferwise/kafka/tkms/demoapp/MessagesProducer.java
+++ b/demoapp/src/main/java/com/transferwise/kafka/tkms/demoapp/MessagesProducer.java
@@ -45,7 +45,7 @@ public class MessagesProducer {
         try {
           for (long i = 0; i < batchCount; i++) {
             long finalI = i;
-            transactionTemplate.executeWithoutResult((status) -> {
+            transactionTemplate.executeWithoutResult(status -> {
               for (long j = 0; j < batchSize; j++) {
                 String key = String.valueOf(finalT * batchCount * batchSize + finalI * batchSize + j);
 

--- a/demoapp/src/main/java/db/migration/postgres/V1__Init.java
+++ b/demoapp/src/main/java/db/migration/postgres/V1__Init.java
@@ -26,9 +26,9 @@ public class V1__Init extends BaseJavaMigration {
       }
     }
   }
-  
+
   @Override
-  public boolean canExecuteInTransaction(){
+  public boolean canExecuteInTransaction() {
     return false;
   }
 }

--- a/demoapp/src/main/resources/application.yml
+++ b/demoapp/src/main/resources/application.yml
@@ -36,6 +36,9 @@ tw-tkms:
     bootstrap.servers: "localhost:9092"
   environment:
     previous-version: 0.7.3
+  earliest-visible-messages:
+    enabled: false
+    look-back-period: 10s
 
 tw-graceful-shutdown:
   clients-reaction-time-ms: 10000

--- a/demoapp/src/main/resources/db/migration/mysql/V2__CollectorTable.sql
+++ b/demoapp/src/main/resources/db/migration/mysql/V2__CollectorTable.sql
@@ -1,6 +1,7 @@
-CREATE TABLE complex_test_messages (
-  id BIGINT AUTO_INCREMENT PRIMARY KEY,
-  entity_id BIGINT NOT NULL,
-  entity_seq BIGINT NOT NULL,
-  topic VARCHAR(100) NOT NULL
+CREATE TABLE complex_test_messages
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    entity_id  BIGINT       NOT NULL,
+    entity_seq BIGINT       NOT NULL,
+    topic      VARCHAR(100) NOT NULL
 );

--- a/demoapp/src/main/resources/db/migration/mysql/V3__earliest_visible_message.sql
+++ b/demoapp/src/main/resources/db/migration/mysql/V3__earliest_visible_message.sql
@@ -1,0 +1,7 @@
+CREATE TABLE tw_tkms_earliest_visible_messages
+(
+    shard      BIGINT NOT NULL,
+    part       BIGINT NOT NULL,
+    message_id BIGINT NOT NULL,
+    PRIMARY KEY (shard, part)
+) 

--- a/demoapp/src/main/resources/db/migration/postgres/V2__CollectorTable.sql
+++ b/demoapp/src/main/resources/db/migration/postgres/V2__CollectorTable.sql
@@ -1,6 +1,7 @@
-CREATE TABLE complex_test_messages (
-  id BIGSERIAL PRIMARY KEY,
-  entity_id BIGINT NOT NULL,
-  entity_seq BIGINT NOT NULL,
-  topic TEXT NOT NULL
+CREATE TABLE complex_test_messages
+(
+    id BIGSERIAL PRIMARY KEY,
+    entity_id  BIGINT NOT NULL,
+    entity_seq BIGINT NOT NULL,
+    topic      TEXT   NOT NULL
 );

--- a/demoapp/src/main/resources/db/migration/postgres/V3__earliest_visible_message.sql
+++ b/demoapp/src/main/resources/db/migration/postgres/V3__earliest_visible_message.sql
@@ -1,0 +1,7 @@
+CREATE TABLE tw_tkms_earliest_visible_messages
+(
+    shard      BIGINT NOT NULL,
+    part       BIGINT NOT NULL,
+    message_id BIGINT NOT NULL,
+    PRIMARY KEY (shard, part)
+) 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -18,6 +18,14 @@ Notation used: `metric_name {tag1, tag2, tag3...}`
 
 `tw_library_info {library, version}`
 
+`tw_tkms_proxy_earliest_message_id {shard, partition}`
+
+`tw_tkms_dao_rows_in_table_stats {shard, partition}`
+
+`tw_tkms_dao_rows_in_index_stats {shard, partition}`
+
+`tw_tkms_dao_approximate_messages_count {shard, partition}`
+
 ### Summaries
 
 `tw_tkms_dao_poll_all_results_count {shard, partition}`

--- a/docs/postgres_with_long_transactions.md
+++ b/docs/postgres_with_long_transactions.md
@@ -12,7 +12,7 @@ The longer the transactions take, the worse it gets.
 
 The problem comes from the fact, that Postgres can not remove dead tuples, until the last transaction possibly needing those has finished.
 
-So if we look at the messages polling with `select id, message from outgoing_message_0,0 order by id limit 1000`, it starts to look
+So if we look at the messages polling with `select id, message from outgoing_message_0,0 order by id`, it starts to look
 like following on database side, for new transactions.
 
 ```
@@ -24,7 +24,7 @@ message #1000001 (live tuple)
 ```
 
 A person without understanding about Postgres internals, would assume the query above would be lightning fast, but it is not. It actually iterates
-over all those million dead tuples and then return 1 record.
+over all those million dead tuples and then returns 1 record.
 
 It can be described with the following pseudocode:
 

--- a/docs/postgres_with_long_transactions.md
+++ b/docs/postgres_with_long_transactions.md
@@ -1,0 +1,83 @@
+# Postgres with long running transactions
+
+## The problem
+
+When `tw-tkms` is running on a Postgres database with long running transactions, the following happens.
+
+- Database starts using more and more CPU.
+- `tw-tkms` throughput plummets.
+- latency for sending out messages increases.
+
+The longer the transactions take, the worse it gets.
+
+The problem comes from the fact, that Postgres can not remove dead tuples, until the last transaction possibly needing those has finished.
+
+So if we look at the messages polling with `select id, message from outgoing_message_0,0 order by id limit 1000`, it starts to look
+like following on database side, for new transactions.
+
+```
+message #0 (dead tuple)
+message #1 (dead tuple)
+...
+message #1000000 (dead tuple)
+message #1000001 (live tuple)
+```
+
+A person without understanding about Postgres internals, would assume the query above would be lightning fast, but it is not. It actually iterates
+over all those million dead tuples and then return 1 record.
+
+It can be described with the following pseudocode:
+
+```
+record = findARecordFromPrimaryIndexVisibleForAnyTransaction() -- 0
+
+do{
+    if (record.isVisibleToCurrentTransaction()){
+        result.append(record)
+    }
+}
+until record.nextInPrimaryIndex() == nil
+```
+
+## The solution
+
+In the previous case, if we could also add a clause `where id >= 1000000`, the `findARecordFromPrimaryIndexVisibleForAnyTransaction`
+can find the right record to start looping from instantly and the whole query will be fast.
+
+What `tw-tkms` can do, is to track ids it has loaded from the database in a sliding window, let's say 5 minutes long by default.
+
+And, then add `where id >= [earliest id in 5 minute period]` clause to every polling query.
+
+To enabling it you need to create a tracking table and then turn it on from config.
+
+```postgresql
+CREATE TABLE tw_tkms_earliest_visible_messages
+(
+    shard      BIGINT NOT NULL,
+    part       BIGINT NOT NULL,
+    message_id BIGINT NOT NULL,
+    PRIMARY KEY (shard, part)
+) 
+```
+
+```yaml
+tw-tkms:
+  earliest-visible-messages:
+    enabled: true
+    look-back-period: 5m
+```
+
+## The risk
+
+If you configure the `look-back-period` too small, you may have longer transactions adding messages too late and
+`tw-tkms` will not see them anymore.
+
+You should be really sure about that how long transactions, in which you are sending out tw-tkms messages, your application  
+creates and protect yourself against it. 
+
+Postgres lacks a way to directly set a maximum timeout for a transaction, but you can use `tw-reliable-jdbc`, which
+at least helps to keep `statement_timeout` and `idle_in_transaction_session_timeout` small, making longer than expected
+transactions highly improbable.
+
+If the worst case happens and some messages are left behind into the outbox tables, you can turn the
+`tw-tkms.earliest-visible-message.enabled` to `false` and do a temporary deployment. 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.13.0
+version=0.14.0

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/EarliestMessageSlidingWindow.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/EarliestMessageSlidingWindow.java
@@ -1,0 +1,78 @@
+package com.transferwise.kafka.tkms;
+
+import java.time.Duration;
+
+public class EarliestMessageSlidingWindow {
+
+  private static final int BUCKETS_COUNT = 100;
+
+  private long[] buckets;
+  private long stepMs;
+  private int idx;
+  private long idxMs;
+  private long initializationMs = -1;
+  private long periodMs;
+
+  public EarliestMessageSlidingWindow(Duration lookBackPeriod) {
+    buckets = new long[BUCKETS_COUNT];
+    periodMs = lookBackPeriod.toMillis();
+    stepMs = periodMs / BUCKETS_COUNT;
+    for (int i = 0; i < BUCKETS_COUNT; i++) {
+      buckets[i] = Long.MAX_VALUE;
+    }
+
+    idxMs = TkmsClockHolder.getClock().millis();
+  }
+
+  public void register(long id) {
+    scroll();
+
+    if (initializationMs == -1) {
+      initializationMs = TkmsClockHolder.getClock().millis();
+    }
+
+    if (id < buckets[idx]) {
+      buckets[idx] = id;
+    }
+  }
+
+  private void scroll() {
+    long timeMs = TkmsClockHolder.getClock().millis();
+
+    if (timeMs > idxMs + BUCKETS_COUNT * stepMs) {
+      idxMs = timeMs;
+      idx = 0;
+      for (int i = 0; i < BUCKETS_COUNT; i++) {
+        buckets[i] = Long.MAX_VALUE;
+      }
+    }
+
+    while (timeMs > idxMs + stepMs) {
+      idx += 1;
+      idxMs += stepMs;
+
+      if (idx >= BUCKETS_COUNT) {
+        idx = 0;
+      }
+
+      buckets[idx] = Long.MAX_VALUE;
+    }
+  }
+
+  public long getEarliestMessageId() {
+    if (TkmsClockHolder.getClock().millis() - initializationMs <= periodMs) {
+      // We can't return an id, before first period finishes.
+      return -1;
+    }
+
+    scroll();
+
+    long earliestMessageId = Long.MAX_VALUE;
+    for (int i = 0; i < BUCKETS_COUNT; i++) {
+      if (buckets[i] < earliestMessageId) {
+        earliestMessageId = buckets[i];
+      }
+    }
+    return earliestMessageId == Long.MAX_VALUE ? -1 : earliestMessageId;
+  }
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/EarliestMessageTracker.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/EarliestMessageTracker.java
@@ -1,0 +1,86 @@
+package com.transferwise.kafka.tkms;
+
+import com.transferwise.kafka.tkms.api.TkmsShardPartition;
+import com.transferwise.kafka.tkms.config.TkmsProperties;
+import com.transferwise.kafka.tkms.config.TkmsProperties.EarliestVisibleMessages;
+import com.transferwise.kafka.tkms.dao.ITkmsDao;
+import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
+
+public class EarliestMessageTracker {
+
+  private ITkmsDao dao;
+  private TkmsShardPartition shardPartition;
+  private TkmsProperties properties;
+  private ITkmsMetricsTemplate metricsTemplate;
+
+  private boolean enabled;
+  private Object earliestMessageIdGauge;
+
+  private long earliestMessageId = -1;
+
+  private long lastCommitMs = -1;
+
+  private EarliestMessageSlidingWindow earliestMessageSlidingWindow;
+
+  public EarliestMessageTracker(TkmsShardPartition shardPartition, ITkmsDao dao, TkmsProperties properties, ITkmsMetricsTemplate metricsTemplate) {
+    this.dao = dao;
+    this.shardPartition = shardPartition;
+    this.properties = properties;
+    this.metricsTemplate = metricsTemplate;
+  }
+
+  public void init() {
+    earliestMessageIdGauge = metricsTemplate.registerEarliestMessageId(shardPartition, () -> earliestMessageId);
+
+    EarliestVisibleMessages earliestVisibleMessages = properties.getEarliestVisibleMessages(shardPartition.getShard());
+    enabled = earliestVisibleMessages.isEnabled();
+
+    if (!enabled) {
+      return;
+    }
+
+    earliestMessageSlidingWindow = new EarliestMessageSlidingWindow(earliestVisibleMessages.getLookBackPeriod());
+    Long earliestMessageIdFromDb = dao.getEarliestMessageId(shardPartition);
+    earliestMessageId = earliestMessageIdFromDb == null ? -1 : earliestMessageIdFromDb;
+  }
+
+  public void shutdown() {
+    metricsTemplate.deRegisterEarliestMessageId(earliestMessageIdGauge);
+    if (!enabled) {
+      return;
+    }
+
+    commit();
+  }
+
+  public Long getEarliestMessageId() {
+    return earliestMessageId;
+  }
+
+  public void register(long id) {
+    if (!enabled) {
+      return;
+    }
+
+    earliestMessageSlidingWindow.register(id);
+
+    long earliestMessageId = earliestMessageSlidingWindow.getEarliestMessageId();
+    if (earliestMessageId != -1) {
+      this.earliestMessageId = earliestMessageId;
+    }
+
+    commitIfFeasible();
+  }
+
+  private void commitIfFeasible() {
+    if (lastCommitMs == -1 || TkmsClockHolder.getClock().millis() - lastCommitMs > 5000) {
+      commit();
+    }
+  }
+
+  private void commit() {
+    metricsTemplate.registerEarliestMessageIdCommit(shardPartition);
+    lastCommitMs = TkmsClockHolder.getClock().millis();
+    dao.saveEarliestMessageId(shardPartition, earliestMessageId);
+  }
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/EarliestMessageTracker.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/EarliestMessageTracker.java
@@ -64,9 +64,9 @@ public class EarliestMessageTracker {
 
     earliestMessageSlidingWindow.register(id);
 
-    long earliestMessageId = earliestMessageSlidingWindow.getEarliestMessageId();
-    if (earliestMessageId != -1) {
-      this.earliestMessageId = earliestMessageId;
+    long earliestMessageIdInWindow = earliestMessageSlidingWindow.getEarliestMessageId();
+    if (earliestMessageIdInWindow != -1) {
+      this.earliestMessageId = earliestMessageIdInWindow;
     }
 
     commitIfFeasible();

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/EarliestMessageTracker.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/EarliestMessageTracker.java
@@ -5,7 +5,9 @@ import com.transferwise.kafka.tkms.config.TkmsProperties;
 import com.transferwise.kafka.tkms.config.TkmsProperties.EarliestVisibleMessages;
 import com.transferwise.kafka.tkms.dao.ITkmsDao;
 import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
+import javax.annotation.concurrent.NotThreadSafe;
 
+@NotThreadSafe
 public class EarliestMessageTracker {
 
   private ITkmsDao dao;
@@ -45,7 +47,7 @@ public class EarliestMessageTracker {
   }
 
   public void shutdown() {
-    metricsTemplate.deRegisterEarliestMessageId(earliestMessageIdGauge);
+    metricsTemplate.unregisterMetric(earliestMessageIdGauge);
     if (!enabled) {
       return;
     }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsClockHolder.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsClockHolder.java
@@ -17,4 +17,8 @@ public class TkmsClockHolder {
   public static Clock getClock() {
     return clock;
   }
+
+  private TkmsClockHolder() {
+    
+  }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsClockHolder.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsClockHolder.java
@@ -1,0 +1,20 @@
+package com.transferwise.kafka.tkms;
+
+import java.time.Clock;
+
+public class TkmsClockHolder {
+
+  private static Clock clock = Clock.systemUTC();
+
+  public static void setClock(Clock clock) {
+    TkmsClockHolder.clock = clock;
+  }
+
+  public static void reset() {
+    clock = Clock.systemUTC();
+  }
+
+  public static Clock getClock() {
+    return clock;
+  }
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsMessageInterceptors.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsMessageInterceptors.java
@@ -43,7 +43,7 @@ public class TkmsMessageInterceptors implements ITkmsMessageInterceptors {
       Map<Integer, MessageInterceptionDecision> decisions = interceptor.beforeSendingToKafka(shardPartition, producerRecords);
       if (decisions != null) {
         result.forEach((k, v) -> {
-          if (result.get(k) == MessageInterceptionDecision.NEUTRAL) {
+          if (v == MessageInterceptionDecision.NEUTRAL) {
             MessageInterceptionDecision decision = decisions.get(k);
             if (decision != null && decision != MessageInterceptionDecision.NEUTRAL) {
               result.put(k, decision);

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsStorageToKafkaProxy.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsStorageToKafkaProxy.java
@@ -98,18 +98,18 @@ public class TkmsStorageToKafkaProxy implements GracefulShutdownStrategy, ITkmsS
           AtomicReference<Future<Boolean>> futureReference = new AtomicReference<>();
 
           control.workAsyncUntilShouldStop(() -> futureReference.set(executorService.submit(
-              () -> {
-                try {
-                  log.info("Starting to proxy {}.", shardPartition);
-                  poll(control, shardPartition);
-                  return true;
-                } catch (Throwable t) {
-                  log.error(t.getMessage(), t);
-                  return false;
-                } finally {
-                  control.yield();
-                }
-              })),
+                  () -> {
+                    try {
+                      log.info("Starting to proxy {}.", shardPartition);
+                      poll(control, shardPartition);
+                      return true;
+                    } catch (Throwable t) {
+                      log.error(t.getMessage(), t);
+                      return false;
+                    } finally {
+                      control.yield();
+                    }
+                  })),
               () -> {
                 log.info("Stopping proxying for {}.", shardPartition);
 

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsZookeeperOperations.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsZookeeperOperations.java
@@ -6,9 +6,9 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.util.StringUtils;
 
 @Slf4j
 public class TkmsZookeeperOperations implements ITkmsZookeeperOperations {
@@ -23,7 +23,6 @@ public class TkmsZookeeperOperations implements ITkmsZookeeperOperations {
 
   @PostConstruct
   public void init() {
-
     String groupId = properties.getGroupId();
     if (StringUtils.isEmpty(groupId)) {
       groupId = applicationName;

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSender.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSender.java
@@ -54,7 +54,6 @@ public class TransactionalKafkaMessageSender implements ITransactionalKafkaMessa
   public void init() {
     environmentValidator.validate();
 
-    metricsTemplate.registerLibrary();
     for (String topic : properties.getTopics()) {
       validateTopic(properties.getDefaultShard(), topic);
     }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/TkmsShardPartition.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/TkmsShardPartition.java
@@ -2,9 +2,11 @@ package com.transferwise.kafka.tkms.api;
 
 import com.transferwise.kafka.tkms.config.TkmsProperties;
 import io.micrometer.core.instrument.Tag;
+import lombok.EqualsAndHashCode;
 import lombok.Value;
 
 @Value
+@EqualsAndHashCode(of = {"shard", "partition"})
 public class TkmsShardPartition {
 
   private int shard;

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsAutoConfiguration.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsAutoConfiguration.java
@@ -11,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
 
 @Configuration

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsAutoConfiguration.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsAutoConfiguration.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
 
 @Configuration
@@ -29,10 +30,11 @@ public class TkmsAutoConfiguration {
   public IMeterCache twDefaultMeterCache(MeterRegistry meterRegistry) {
     return new MeterCache(meterRegistry);
   }
-  
+
   @Bean
   @ConditionalOnMissingBean(ITransactionsHelper.class)
   public TransactionsHelper twTransactionsHelper() {
     return new TransactionsHelper();
   }
+
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsConfiguration.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsConfiguration.java
@@ -23,6 +23,7 @@ import com.transferwise.kafka.tkms.dao.TkmsDao;
 import com.transferwise.kafka.tkms.dao.TkmsMessageSerializer;
 import com.transferwise.kafka.tkms.dao.TkmsPostgresDao;
 import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
+import com.transferwise.kafka.tkms.metrics.TkmsClusterWideStateMonitor;
 import com.transferwise.kafka.tkms.metrics.TkmsMetricsTemplate;
 import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +34,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.core.env.Environment;
 
 /**
@@ -98,6 +100,7 @@ public class TkmsConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(ITkmsDataSourceProvider.class)
+  @DependsOn({"flywayInitializer", "flyway"})
   public TkmsDataSourceProvider tkmsDataSourceProvider(
       @Autowired(required = false) @Tkms DataSource dataSource, ConfigurableListableBeanFactory beanFactory) {
     if (dataSource == null) {
@@ -147,4 +150,11 @@ public class TkmsConfiguration {
   public EnvironmentValidator tkmsMigrationHandler() {
     return new EnvironmentValidator();
   }
+
+  @Bean
+  @ConditionalOnMissingBean(TkmsClusterWideStateMonitor.class)
+  public TkmsClusterWideStateMonitor tkmsClusterWideStateMonitor() {
+    return new TkmsClusterWideStateMonitor();
+  }
+
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -130,7 +130,7 @@ public class TkmsProperties {
 
   /**
    * Minimum polling interval, overrides all other relevant settings.
-   * 
+   *
    * <p>Can be useful in development environments, where environment owner wants to restrict resource usages globally.
    */
   private Duration minPollingInterval;
@@ -143,6 +143,8 @@ public class TkmsProperties {
    * <p>Also, so we can warm up their metadata, avoiding elevated latencies at the start of the service.
    */
   private List<String> topics = new ArrayList<>();
+
+  private EarliestVisibleMessages earliestVisibleMessages = new EarliestVisibleMessages();
 
   /**
    * Additional or overridden properties for kafka consumers.
@@ -160,6 +162,8 @@ public class TkmsProperties {
 
   private Environment environment = new Environment();
 
+  private Monitoring monitoring = new Monitoring();
+
   @Data
   @Accessors(chain = true)
   public static class ShardProperties {
@@ -171,6 +175,7 @@ public class TkmsProperties {
     private Integer insertBatchSize;
     private boolean compressionOverridden;
     private Compression compression = new Compression();
+    private EarliestVisibleMessages earliestVisibleMessages;
 
     private Map<String, String> kafka = new HashMap<>();
   }
@@ -223,6 +228,14 @@ public class TkmsProperties {
     return compression;
   }
 
+  public EarliestVisibleMessages getEarliestVisibleMessages(int shard) {
+    ShardProperties shardProperties = shards.get(shard);
+    if (shardProperties != null && shardProperties.getEarliestVisibleMessages() != null) {
+      return shardProperties.getEarliestVisibleMessages();
+    }
+    return earliestVisibleMessages;
+  }
+
   public enum DatabaseDialect {
     POSTGRES,
     MYSQL
@@ -251,5 +264,24 @@ public class TkmsProperties {
   public static class Environment {
 
     private String previousVersion;
+  }
+
+  @Data
+  @Accessors(chain = true)
+  public static class EarliestVisibleMessages {
+
+    private boolean enabled = false;
+
+    private String tableName = "tw_tkms_earliest_visible_messages";
+
+    private Duration lookBackPeriod = Duration.ofMinutes(5);
+  }
+
+  @Data
+  @Accessors(chain = true)
+  public static class Monitoring {
+
+    private Duration interval = Duration.ofSeconds(30);
+    private Duration startDelay = Duration.ofSeconds(30);
   }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -283,5 +283,8 @@ public class TkmsProperties {
 
     private Duration interval = Duration.ofSeconds(30);
     private Duration startDelay = Duration.ofSeconds(30);
+    
+    private Duration leftOverMessagesCheckInterval = Duration.ofHours(1);
+    private Duration leftOverMessagesCheckStartDelay = Duration.ofHours(1);
   }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/ITkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/ITkmsDao.java
@@ -3,6 +3,7 @@ package com.transferwise.kafka.tkms.dao;
 import com.transferwise.kafka.tkms.TkmsMessageWithSequence;
 import com.transferwise.kafka.tkms.api.TkmsMessage;
 import com.transferwise.kafka.tkms.api.TkmsShardPartition;
+import com.transferwise.kafka.tkms.metrics.MonitoringQuery;
 import com.transferwise.kafka.tkms.stored_message.StoredMessage;
 import java.util.List;
 import lombok.Data;
@@ -14,7 +15,11 @@ public interface ITkmsDao {
 
   List<InsertMessageResult> insertMessages(TkmsShardPartition shardPartition, List<TkmsMessageWithSequence> tkmsMessages);
 
+  @MonitoringQuery
   long getApproximateMessagesCount(TkmsShardPartition sp);
+
+  @MonitoringQuery
+  boolean hasMessagesBeforeId(TkmsShardPartition sp, Long messageId);
 
   @Data
   @Accessors(chain = true)

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/ITkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/ITkmsDao.java
@@ -4,9 +4,7 @@ import com.transferwise.kafka.tkms.TkmsMessageWithSequence;
 import com.transferwise.kafka.tkms.api.TkmsMessage;
 import com.transferwise.kafka.tkms.api.TkmsShardPartition;
 import com.transferwise.kafka.tkms.stored_message.StoredMessage;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import lombok.Data;
 import lombok.experimental.Accessors;
 

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/ITkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/ITkmsDao.java
@@ -4,7 +4,9 @@ import com.transferwise.kafka.tkms.TkmsMessageWithSequence;
 import com.transferwise.kafka.tkms.api.TkmsMessage;
 import com.transferwise.kafka.tkms.api.TkmsShardPartition;
 import com.transferwise.kafka.tkms.stored_message.StoredMessage;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -13,6 +15,8 @@ public interface ITkmsDao {
   InsertMessageResult insertMessage(TkmsShardPartition shardPartition, TkmsMessage message);
 
   List<InsertMessageResult> insertMessages(TkmsShardPartition shardPartition, List<TkmsMessageWithSequence> tkmsMessages);
+
+  long getApproximateMessagesCount(TkmsShardPartition sp);
 
   @Data
   @Accessors(chain = true)
@@ -23,9 +27,7 @@ public interface ITkmsDao {
     private TkmsShardPartition shardPartition;
   }
 
-  List<MessageRecord> getMessages(TkmsShardPartition shardPartition, int maxCount);
-
-  void deleteMessages(TkmsShardPartition shardPartition, List<Long> records);
+  List<MessageRecord> getMessages(TkmsShardPartition shardPartition, long earliestMessageId, int maxCount);
 
   @Data
   @Accessors(chain = true)
@@ -34,4 +36,13 @@ public interface ITkmsDao {
     private long id;
     private StoredMessage.Message message;
   }
+
+  void deleteMessages(TkmsShardPartition shardPartition, List<Long> records);
+
+  Long getEarliestMessageId(TkmsShardPartition shardPartition);
+
+  void saveEarliestMessageId(TkmsShardPartition shardPartition, long messageId);
+
+  boolean insertEarliestMessageId(TkmsShardPartition shardPartition);
+
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
@@ -15,7 +15,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -71,6 +70,15 @@ public class TkmsDao implements ITkmsDao {
 
     currentSchema = getCurrentSchema();
 
+    createInsertMessagesSqls();
+    createGetMessagesSqls();
+    createDeleteMessagesSqls();
+
+    validateSchema();
+    validateEngineSpecificSchema();
+  }
+
+  protected void createInsertMessagesSqls() {
     Map<TkmsShardPartition, String> map = new HashMap<>();
     for (int s = 0; s < properties.getShardsCount(); s++) {
       for (int p = 0; p < properties.getPartitionsCount(s); p++) {
@@ -79,7 +87,10 @@ public class TkmsDao implements ITkmsDao {
       }
     }
     insertMessageSqls = ImmutableMap.copyOf(map);
+  }
 
+  protected void createGetMessagesSqls() {
+    Map<TkmsShardPartition, String> map = new HashMap<>();
     map.clear();
     for (int s = 0; s < properties.getShardsCount(); s++) {
       for (int p = 0; p < properties.getPartitionsCount(s); p++) {
@@ -88,7 +99,9 @@ public class TkmsDao implements ITkmsDao {
       }
     }
     getMessagesSqls = ImmutableMap.copyOf(map);
+  }
 
+  protected void createDeleteMessagesSqls() {
     deleteSqlsMap = new HashMap<>();
 
     for (int s = 0; s < properties.getShardsCount(); s++) {
@@ -108,8 +121,6 @@ public class TkmsDao implements ITkmsDao {
       }
     }
     deleteSqlsMap = ImmutableMap.copyOf(deleteSqlsMap);
-
-    validateSchema();
   }
 
   protected void validateSchema() {
@@ -134,8 +145,6 @@ public class TkmsDao implements ITkmsDao {
         }
       }
     }
-
-    validateEngineSpecificSchema();
   }
 
   protected void validateEngineSpecificSchema() {
@@ -303,7 +312,7 @@ public class TkmsDao implements ITkmsDao {
     var ids =
         jdbcTemplate.queryForList("select message_id from " + earliestVisibleMessages.getTableName() + " where shard=? and part=?", Long.class,
             shardPartition.getShard(), shardPartition.getPartition());
-    return ids.size() == 0 ? null : ids.get(0);
+    return ids.isEmpty() ? null : ids.get(0);
   }
 
   @Override

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
@@ -156,7 +156,7 @@ public class TkmsDao implements ITkmsDao {
 
   protected void validateEngineSpecificSchema() {
     for (int s = 0; s < properties.getShardsCount(); s++) {
-      for (int p = 0; p < properties.getPartitionsCount(); p++) {
+      for (int p = 0; p < properties.getPartitionsCount(s); p++) {
         TkmsShardPartition sp = TkmsShardPartition.of(s, p);
 
         long rowsInTableStats = getRowsFromTableStats(sp);

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
@@ -73,19 +73,21 @@ public class TkmsPostgresDao extends TkmsDao {
   }
 
   protected long getDistinctIdsCount(TkmsShardPartition sp) {
-    String relOptions =
-        jdbcTemplate.queryForObject("select attoptions from pg_attribute, pg_class, pg_namespace where pg_class.oid = pg_attribute.attrelid "
+    List<String> relOptionsList =
+        jdbcTemplate.queryForList("select attoptions from pg_attribute, pg_class, pg_namespace where pg_class.oid = pg_attribute.attrelid "
             + "and pg_class.relnamespace = pg_namespace.oid "
             + "and pg_namespace.nspname=? and pg_class.relname=? and attname='id'", String.class, getSchemaName(sp), getTableNameWithoutSchema(sp));
 
-    if (relOptions == null) {
+    if (relOptionsList.isEmpty()) {
       return -1;
     }
+
+    String relOptions = relOptionsList.get(0);
 
     Matcher m = N_DISTINCT_PATTERN.matcher(relOptions);
 
     if (m.find()) {
-      Long value =  Longs.tryParse(relOptions.substring(m.start(1), m.end(1)));
+      Long value = Longs.tryParse(relOptions.substring(m.start(1), m.end(1)));
       return value == null ? -1 : value;
     } else {
       return -1;

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
@@ -1,16 +1,94 @@
 package com.transferwise.kafka.tkms.dao;
 
+import com.google.common.primitives.Longs;
 import com.transferwise.kafka.tkms.api.TkmsShardPartition;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 public class TkmsPostgresDao extends TkmsDao {
+
+  public static final Pattern N_DISTINCT_PATTERN = Pattern.compile("n_distinct=(.*)[,}]");
 
   @Override
   protected String getInsertSql(TkmsShardPartition shardPartition) {
     return "insert into " + getTableName(shardPartition) + " (message) values (?) returning id";
   }
-  
+
   @Override
   protected String getSelectSql(TkmsShardPartition shardPartition) {
-    return "select id, message from " + getTableName(shardPartition) + " order by id limit ?";
+    return "select id, message from " + getTableName(shardPartition) + " where id >= ? order by id limit ?";
+  }
+
+  @Override
+  protected boolean doesEarliestVisibleMessagesTableExist() {
+    String schema = currentSchema;
+    String table = properties.getEarliestVisibleMessages().getTableName();
+    if (StringUtils.contains(table, ".")) {
+      schema = StringUtils.substringBefore(table, ".");
+      table = StringUtils.substringAfter(table, ".");
+    }
+
+    return !jdbcTemplate.queryForList("SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", String.class,
+        schema, table).isEmpty();
+  }
+
+  @Override
+  protected String getCurrentSchema() {
+    return jdbcTemplate.queryForObject("select current_schema()", String.class);
+  }
+
+  @Override
+  protected void validateEngineSpecificSchema() {
+    for (int s = 0; s < properties.getShardsCount(); s++) {
+      for (int p = 0; p < properties.getPartitionsCount(); p++) {
+        TkmsShardPartition sp = TkmsShardPartition.of(s, p);
+
+        long distinctIdsCount = getDistinctIdsCount(sp);
+
+        if (distinctIdsCount < 100000) {
+          log.warn("Table for " + sp + " is not properly configured. Rows from table stats is " + distinctIdsCount
+              + ". This can greatly affect performance during peaks or database slownesses.");
+        }
+
+        metricsTemplate.registerRowsInTableStats(sp, distinctIdsCount);
+      }
+    }
+  }
+
+  @Override
+  @Transactional(rollbackFor = Exception.class, isolation = Isolation.READ_UNCOMMITTED)
+  public long getApproximateMessagesCount(TkmsShardPartition sp) {
+    List<Long> rows =
+        jdbcTemplate.queryForList("SELECT reltuples as approximate_row_count FROM pg_class, pg_namespace WHERE "
+                + " pg_class.relnamespace=pg_namespace.oid and nspname=? and relname = ?", Long.class,
+            getSchemaName(sp), getTableNameWithoutSchema(sp));
+
+    return rows.isEmpty() ? -1 : rows.get(0);
+  }
+
+  protected long getDistinctIdsCount(TkmsShardPartition sp) {
+    String relOptions =
+        jdbcTemplate.queryForObject("select attoptions from pg_attribute, pg_class, pg_namespace where pg_class.oid = pg_attribute.attrelid "
+            + "and pg_class.relnamespace = pg_namespace.oid "
+            + "and pg_namespace.nspname=? and pg_class.relname=? and attname='id'", String.class, getSchemaName(sp), getTableNameWithoutSchema(sp));
+
+    if (relOptions == null) {
+      return -1;
+    }
+
+    Matcher m = N_DISTINCT_PATTERN.matcher(relOptions);
+
+    if (m.find()) {
+      Long value =  Longs.tryParse(relOptions.substring(m.start(1), m.end(1)));
+      return value == null ? -1 : value;
+    } else {
+      return -1;
+    }
   }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
@@ -46,7 +46,7 @@ public class TkmsPostgresDao extends TkmsDao {
   @Override
   protected void validateEngineSpecificSchema() {
     for (int s = 0; s < properties.getShardsCount(); s++) {
-      for (int p = 0; p < properties.getPartitionsCount(); p++) {
+      for (int p = 0; p < properties.getPartitionsCount(s); p++) {
         TkmsShardPartition sp = TkmsShardPartition.of(s, p);
 
         long distinctIdsCount = getDistinctIdsCount(sp);

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/ITkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/ITkmsMetricsTemplate.java
@@ -1,8 +1,13 @@
 package com.transferwise.kafka.tkms.metrics;
 
+import com.transferwise.common.baseutils.meters.cache.TagsSet;
 import com.transferwise.kafka.tkms.CompressionAlgorithm;
 import com.transferwise.kafka.tkms.api.TkmsShardPartition;
+import io.micrometer.core.instrument.Meter;
 import java.time.Instant;
+import java.util.function.Supplier;
+import lombok.Data;
+import lombok.experimental.Accessors;
 
 public interface ITkmsMetricsTemplate {
 
@@ -38,4 +43,18 @@ public interface ITkmsMetricsTemplate {
       long serializedSizeBytes);
 
   void recordDaoInvalidGeneratedKeysCount(TkmsShardPartition shardPartition);
+
+  Object registerEarliestMessageId(TkmsShardPartition shardPartition, Supplier<Number> supplier);
+
+  void deRegisterEarliestMessageId(Object handle);
+
+  void registerRowsInTableStats(TkmsShardPartition sp, long rowsInTableStats);
+
+  void registerRowsInIndexStats(TkmsShardPartition sp, long rowsInIndexStats);
+  
+  void unregisterMetric(Object rawMetricHandle);
+
+  Object registerApproximateMessagesCount(TkmsShardPartition sp, Supplier<Number> supplier);
+
+  void registerEarliestMessageIdCommit(TkmsShardPartition shardPartition);
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/ITkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/ITkmsMetricsTemplate.java
@@ -1,13 +1,9 @@
 package com.transferwise.kafka.tkms.metrics;
 
-import com.transferwise.common.baseutils.meters.cache.TagsSet;
 import com.transferwise.kafka.tkms.CompressionAlgorithm;
 import com.transferwise.kafka.tkms.api.TkmsShardPartition;
-import io.micrometer.core.instrument.Meter;
 import java.time.Instant;
 import java.util.function.Supplier;
-import lombok.Data;
-import lombok.experimental.Accessors;
 
 public interface ITkmsMetricsTemplate {
 
@@ -51,7 +47,7 @@ public interface ITkmsMetricsTemplate {
   void registerRowsInTableStats(TkmsShardPartition sp, long rowsInTableStats);
 
   void registerRowsInIndexStats(TkmsShardPartition sp, long rowsInIndexStats);
-  
+
   void unregisterMetric(Object rawMetricHandle);
 
   Object registerApproximateMessagesCount(TkmsShardPartition sp, Supplier<Number> supplier);

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/ITkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/ITkmsMetricsTemplate.java
@@ -42,8 +42,6 @@ public interface ITkmsMetricsTemplate {
 
   Object registerEarliestMessageId(TkmsShardPartition shardPartition, Supplier<Number> supplier);
 
-  void deRegisterEarliestMessageId(Object handle);
-
   void registerRowsInTableStats(TkmsShardPartition sp, long rowsInTableStats);
 
   void registerRowsInIndexStats(TkmsShardPartition sp, long rowsInIndexStats);

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/MonitoringQuery.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/MonitoringQuery.java
@@ -1,0 +1,22 @@
+package com.transferwise.kafka.tkms.metrics;
+
+import static java.lang.annotation.ElementType.METHOD;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Query does not need to provide real time or consecutively consistent results.
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target(value = {METHOD})
+public @interface MonitoringQuery {
+
+  // Alias for comment
+  String value() default "";
+
+  String[] comment() default {};
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsClusterWideStateMonitor.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsClusterWideStateMonitor.java
@@ -1,0 +1,158 @@
+package com.transferwise.kafka.tkms.metrics;
+
+import com.transferwise.common.baseutils.concurrency.IExecutorServicesProvider;
+import com.transferwise.common.baseutils.concurrency.ScheduledTaskExecutor;
+import com.transferwise.common.baseutils.concurrency.ScheduledTaskExecutor.TaskHandle;
+import com.transferwise.common.baseutils.concurrency.ThreadNamingExecutorServiceWrapper;
+import com.transferwise.common.context.UnitOfWorkManager;
+import com.transferwise.common.gracefulshutdown.GracefulShutdownStrategy;
+import com.transferwise.common.leaderselector.ILock;
+import com.transferwise.common.leaderselector.LeaderSelectorV2;
+import com.transferwise.common.leaderselector.SharedReentrantLockBuilderFactory;
+import com.transferwise.kafka.tkms.api.TkmsShardPartition;
+import com.transferwise.kafka.tkms.config.TkmsProperties;
+import com.transferwise.kafka.tkms.dao.ITkmsDao;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.mutable.MutableObject;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Slf4j
+public class TkmsClusterWideStateMonitor implements GracefulShutdownStrategy {
+
+  @Autowired
+  private ITkmsDao tkmsDao;
+  @Autowired
+  private SharedReentrantLockBuilderFactory lockBuilderFactory;
+  @Autowired
+  private ITkmsMetricsTemplate coreMetricsTemplate;
+  @Autowired
+  private TkmsProperties properties;
+  @Autowired
+  private IExecutorServicesProvider executorServicesProvider;
+  @Autowired
+  private UnitOfWorkManager unitOfWorkManager;
+
+  private LeaderSelectorV2 leaderSelector;
+  private final Lock stateLock = new ReentrantLock();
+
+  private Map<TkmsShardPartition, AtomicLong> approximateMessagesCount;
+  private List<Object> registeredMetricHandles;
+  private boolean initialized;
+
+  @PostConstruct
+  public void init() {
+    String nodePath = "/tw/tw_tkms/" + properties.getGroupId() + "/tasks_state_monitor";
+
+    ExecutorService executorService = new ThreadNamingExecutorServiceWrapper("tw-tasks-tsm", executorServicesProvider.getGlobalExecutorService());
+    ILock lock = lockBuilderFactory.createBuilder(nodePath).build();
+    leaderSelector = new LeaderSelectorV2.Builder().setLock(lock).setExecutorService(executorService).setLeader(control -> {
+      ScheduledTaskExecutor scheduledTaskExecutor = executorServicesProvider.getGlobalScheduledTaskExecutor();
+      MutableObject<TaskHandle> taskHandleHolder = new MutableObject<>();
+
+      control.workAsyncUntilShouldStop(
+          () -> {
+            resetState(true);
+            TkmsProperties.Monitoring monitoring = properties.getMonitoring();
+            taskHandleHolder.setValue(scheduledTaskExecutor
+                .scheduleAtFixedInterval(this::check, monitoring.getStartDelay(),
+                    monitoring.getInterval()));
+            log.info("Started to monitor tasks state for '" + properties.getGroupId() + "'.");
+          },
+          () -> {
+            log.info("Stopping monitoring of tasks state for '" + properties.getGroupId() + "'.");
+            if (taskHandleHolder.getValue() != null) {
+              taskHandleHolder.getValue().stop();
+              taskHandleHolder.getValue().waitUntilStopped(Duration.ofMinutes(1));
+            }
+            resetState(false);
+            log.info("Monitoring of tasks state stopped.");
+          });
+    }).build();
+
+    coreMetricsTemplate.registerLibrary();
+  }
+
+  protected void resetState(boolean forInit) {
+    unitOfWorkManager.createEntryPoint("TKMS", "MonitorReset").toContext().execute(
+        () -> {
+          stateLock.lock();
+          try {
+            /*
+              The main idea between unregistering the metrics, is to not left 0 or old values lying around in Grafana but make this metric disappear
+              from current node.
+              This will make the picture much more clear and accurate.
+            */
+            if (registeredMetricHandles != null) {
+              for (Object metricHandle : registeredMetricHandles) {
+                coreMetricsTemplate.unregisterMetric(metricHandle);
+              }
+            }
+
+            registeredMetricHandles = new ArrayList<>();
+            approximateMessagesCount = new HashMap<>();
+
+            initialized = forInit;
+          } finally {
+            stateLock.unlock();
+          }
+        });
+  }
+
+  protected void check() {
+    unitOfWorkManager.createEntryPoint("TKMS", "MonitorCheck").toContext().execute(
+        () -> {
+          stateLock.lock();
+          try {
+            if (!initialized) {
+              return;
+            }
+            checkApproximateMessagesCount();
+          } finally {
+            stateLock.unlock();
+          }
+        });
+  }
+
+  protected void checkApproximateMessagesCount() {
+    for (int s = 0; s < properties.getShardsCount(); s++) {
+      for (int p = 0; p < properties.getPartitionsCount(p); p++) {
+        TkmsShardPartition sp = TkmsShardPartition.of(s, p);
+
+        long count = tkmsDao.getApproximateMessagesCount(sp);
+
+        approximateMessagesCount.computeIfAbsent(sp, (k) -> {
+          AtomicLong counter = new AtomicLong(count);
+          registeredMetricHandles.add(coreMetricsTemplate.registerApproximateMessagesCount(sp, () -> counter.get()));
+          return counter;
+        }).set(count);
+      }
+    }
+  }
+
+  @Override
+  public void applicationStarted() {
+    leaderSelector.start();
+  }
+
+  @Override
+  public void prepareForShutdown() {
+    if (leaderSelector != null) {
+      leaderSelector.stop();
+    }
+  }
+
+  @Override
+  public boolean canShutdown() {
+    return leaderSelector == null || leaderSelector.hasStopped();
+  }
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsClusterWideStateMonitor.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsClusterWideStateMonitor.java
@@ -75,7 +75,7 @@ public class TkmsClusterWideStateMonitor implements GracefulShutdownStrategy {
                 continue;
               }
 
-              for (int p = 0; p < properties.getShardsCount(); p++) {
+              for (int p = 0; p < properties.getPartitionsCount(s); p++) {
                 TkmsShardPartition sp = TkmsShardPartition.of(s, p);
                 long startDelayMs =
                     (long) (ThreadLocalRandom.current().nextDouble(0.25) * monitoring.getLeftOverMessagesCheckStartDelay().toMillis());

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsClusterWideStateMonitor.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsClusterWideStateMonitor.java
@@ -130,9 +130,9 @@ public class TkmsClusterWideStateMonitor implements GracefulShutdownStrategy {
 
         long count = tkmsDao.getApproximateMessagesCount(sp);
 
-        approximateMessagesCount.computeIfAbsent(sp, (k) -> {
+        approximateMessagesCount.computeIfAbsent(sp, k -> {
           AtomicLong counter = new AtomicLong(count);
-          registeredMetricHandles.add(coreMetricsTemplate.registerApproximateMessagesCount(sp, () -> counter.get()));
+          registeredMetricHandles.add(coreMetricsTemplate.registerApproximateMessagesCount(sp, counter::get));
           return counter;
         }).set(count);
       }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
@@ -313,11 +313,6 @@ public class TkmsMetricsTemplate implements ITkmsMetricsTemplate {
   }
 
   @Override
-  public void deRegisterEarliestMessageId(Object handle) {
-    unregisterMetric(handle);
-  }
-
-  @Override
   public void registerRowsInTableStats(TkmsShardPartition sp, long rowsInTableStats) {
     Gauge.builder(DAO_ROWS_IN_TABLE_STATS, () -> rowsInTableStats).tags(Tags.of(shardTag(sp), partitionTag(sp)))
         .register(meterCache.getMeterRegistry());

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
@@ -389,12 +389,12 @@ public class TkmsMetricsTemplate implements ITkmsMetricsTemplate {
   public Object registerApproximateMessagesCount(TkmsShardPartition sp, Supplier<Number> supplier) {
     return registerGauge(DAO_APPROXIMATE_MESSAGES_COUNT, supplier, shardTag(sp), partitionTag(sp));
   }
-  
+
   @Override
-  public void registerEarliestMessageIdCommit(TkmsShardPartition shardPartition){
-    meterCache.counter(DAO_EARLIEST_MESSAGE_ID_COMMIT, TagsSet.of(shardTag(shardPartition), partitionTag(shardPartition)))        .increment();
+  public void registerEarliestMessageIdCommit(TkmsShardPartition shardPartition) {
+    meterCache.counter(DAO_EARLIEST_MESSAGE_ID_COMMIT, TagsSet.of(shardTag(shardPartition), partitionTag(shardPartition))).increment();
   }
-  
+
   protected MetricHandle registerGauge(String name, Supplier<Number> supplier, Tag... tags) {
     return new MetricHandle().setMeter(Gauge.builder(name, supplier)
         .tags(Tags.of(tags)).register(meterCache.getMeterRegistry()));

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/ComplexRealTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/ComplexRealTest.java
@@ -21,7 +21,7 @@ import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Disabled("Not meant to be automatically run.")
-public class ComplexRealTest {
+class ComplexRealTest {
 
   private final RestTemplate restTemplate = new RestTemplate();
 

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageSlidingWindowTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageSlidingWindowTest.java
@@ -16,6 +16,7 @@ class EarliestMessageSlidingWindowTest extends BaseIntTest {
 
     EarliestMessageSlidingWindow slidingWindow = new EarliestMessageSlidingWindow(Duration.ofSeconds(10));
 
+    // tick, current message id, expected earliest message id.
     long[][] values = new long[][]{
         {0, 9, -1},
         {1, 12, -1},

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageSlidingWindowTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageSlidingWindowTest.java
@@ -1,0 +1,51 @@
+package com.transferwise.kafka.tkms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.transferwise.common.baseutils.clock.TestClock;
+import com.transferwise.kafka.tkms.test.BaseIntTest;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+public class EarliestMessageSlidingWindowTest extends BaseIntTest {
+
+  @Test
+  void testSlidingWindow() {
+    TestClock clock = new TestClock();
+    TkmsClockHolder.setClock(clock);
+
+    EarliestMessageSlidingWindow slidingWindow = new EarliestMessageSlidingWindow(Duration.ofSeconds(10));
+
+    long[][] values = new long[][]{
+        {0, 9, -1},
+        {1, 12, -1},
+        {1000, 3, -1},
+        {5000, 88, -1},
+        {2000, 5, -1},
+        {1999, 7, -1}, 
+        {1, 7, 3}, // First period finishes
+        {1000, 8, 5},
+        {6999, 9, 5},
+        {1, 9, 7}};
+
+    assertThat(slidingWindow.getEarliestMessageId()).isEqualTo(-1);
+
+    for (int i = 0; i < values.length; i++) {
+      clock.tick(Duration.ofMillis(values[i][0]));
+      slidingWindow.register(values[i][1]);
+      assertThat(slidingWindow.getEarliestMessageId()).isEqualTo(values[i][2]);
+    }
+
+    clock.tick(Duration.ofMillis(9999));
+    assertThat(slidingWindow.getEarliestMessageId()).isEqualTo(9);
+
+    clock.tick(Duration.ofMillis(1));
+    assertThat(slidingWindow.getEarliestMessageId()).isEqualTo(-1);
+
+    clock.tick(Duration.ofSeconds(10));
+    assertThat(slidingWindow.getEarliestMessageId()).isEqualTo(-1);
+
+    slidingWindow.register(13);
+    assertThat(slidingWindow.getEarliestMessageId()).isEqualTo(13);
+  }
+}

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageSlidingWindowTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageSlidingWindowTest.java
@@ -7,7 +7,7 @@ import com.transferwise.kafka.tkms.test.BaseIntTest;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
-public class EarliestMessageSlidingWindowTest extends BaseIntTest {
+class EarliestMessageSlidingWindowTest extends BaseIntTest {
 
   @Test
   void testSlidingWindow() {
@@ -22,7 +22,7 @@ public class EarliestMessageSlidingWindowTest extends BaseIntTest {
         {1000, 3, -1},
         {5000, 88, -1},
         {2000, 5, -1},
-        {1999, 7, -1}, 
+        {1999, 7, -1},
         {1, 7, 3}, // First period finishes
         {1000, 8, 5},
         {6999, 9, 5},
@@ -30,10 +30,10 @@ public class EarliestMessageSlidingWindowTest extends BaseIntTest {
 
     assertThat(slidingWindow.getEarliestMessageId()).isEqualTo(-1);
 
-    for (int i = 0; i < values.length; i++) {
-      clock.tick(Duration.ofMillis(values[i][0]));
-      slidingWindow.register(values[i][1]);
-      assertThat(slidingWindow.getEarliestMessageId()).isEqualTo(values[i][2]);
+    for (long[] value : values) {
+      clock.tick(Duration.ofMillis(value[0]));
+      slidingWindow.register(value[1]);
+      assertThat(slidingWindow.getEarliestMessageId()).isEqualTo(value[2]);
     }
 
     clock.tick(Duration.ofMillis(9999));

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageTrackingIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageTrackingIntTest.java
@@ -61,7 +61,7 @@ public class EarliestMessageTrackingIntTest extends BaseIntTest {
     sendMessageAndWaitForArrival(4);
     assertThat(earliestMessageIdGauge.value()).isGreaterThan(previousValue);
 
-    long committedValue =
+    Long committedValue =
         jdbcTemplate.queryForObject("select message_id from earliestmessage.tw_tkms_earliest_visible_messages where shard=? and part=?", Long.class,
             0, 0);
     assertThat(committedValue).isGreaterThanOrEqualTo((long) previousValue);

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageTrackingIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageTrackingIntTest.java
@@ -1,0 +1,79 @@
+package com.transferwise.kafka.tkms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.transferwise.common.baseutils.clock.TestClock;
+import com.transferwise.kafka.tkms.api.TkmsMessage;
+import com.transferwise.kafka.tkms.api.TkmsShardPartition;
+import com.transferwise.kafka.tkms.config.TkmsProperties;
+import com.transferwise.kafka.tkms.dao.ITkmsDao;
+import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
+import com.transferwise.kafka.tkms.test.BaseIntTest;
+import io.micrometer.core.instrument.Gauge;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("earliest-message")
+public class EarliestMessageTrackingIntTest extends BaseIntTest {
+
+  @Autowired
+  private TransactionalKafkaMessageSender tkms;
+  @Autowired
+  private ITkmsDao dao;
+  @Autowired
+  private TkmsProperties properties;
+  @Autowired
+  private ITkmsMetricsTemplate metricsTemplate;
+
+
+  @Value("${tw-tkms-test.test-topic}")
+  private String testTopic;
+
+  @Test
+  void testIfEarliestMessageTrackerBehavesAsExpected() {
+    TestClock clock = new TestClock();
+    TkmsClockHolder.setClock(clock);
+
+    Gauge earliestMessageIdGauge = await()
+        .until(() -> meterRegistry.find("tw.tkms.dao.earliest.message.id").tags("shard", "0", "partition", "0").gauge(), (g) -> g != null);
+    assertThat(earliestMessageIdGauge.value()).isEqualTo(-1);
+
+    clock.tick(Duration.ofSeconds(5));
+    sendMessageAndWaitForArrival(1);
+
+    assertThat(earliestMessageIdGauge.value()).as("First period has not passed, so earliest message id is not yet usable.").isEqualTo(-1);
+
+    clock.tick(Duration.ofSeconds(6));
+    sendMessageAndWaitForArrival(2);
+    assertThat(earliestMessageIdGauge.value()).as("First 10s period has passed, we should have a id now").isGreaterThanOrEqualTo(0);
+
+    double previousValue = earliestMessageIdGauge.value();
+    clock.tick(Duration.ofSeconds(6));
+    sendMessageAndWaitForArrival(3);
+    assertThat(earliestMessageIdGauge.value()).isGreaterThanOrEqualTo(previousValue);
+
+    clock.tick(Duration.ofSeconds(6));
+    sendMessageAndWaitForArrival(4);
+    assertThat(earliestMessageIdGauge.value()).isGreaterThan(previousValue);
+
+    long committedValue =
+        jdbcTemplate.queryForObject("select message_id from earliestmessage.tw_tkms_earliest_visible_messages where shard=? and part=?", Long.class,
+            0, 0);
+    assertThat(committedValue).isGreaterThanOrEqualTo((long) previousValue);
+
+    EarliestMessageTracker earliestMessageTracker = new EarliestMessageTracker(TkmsShardPartition.of(0, 0), dao, properties, metricsTemplate);
+    earliestMessageTracker.init();
+    
+    assertThat(earliestMessageTracker.getEarliestMessageId()).isEqualTo(committedValue);
+  }
+
+  protected void sendMessageAndWaitForArrival(int cnt) {
+    tkms.sendMessage(new TkmsMessage().setTopic(testTopic).setValue("Hello World!".getBytes(StandardCharsets.UTF_8)));
+    await().until(() -> tkmsSentMessagesCollector.getSentMessages(testTopic).size() == cnt);
+  }
+}

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
@@ -49,7 +49,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 @BaseTestEnvironment
 @Slf4j
-public class EndToEndIntTest extends BaseIntTest {
+class EndToEndIntTest extends BaseIntTest {
 
   @Autowired
   private ObjectMapper objectMapper;
@@ -85,7 +85,7 @@ public class EndToEndIntTest extends BaseIntTest {
   }
 
   @Test
-  public void testThatJsonStringMessageCanBeSentAndRetrieved() throws Exception {
+  void testThatJsonStringMessageCanBeSentAndRetrieved() throws Exception {
     var messagePart = "Hello World!";
     int messageMultiplier = 100;
     StringBuilder sb = new StringBuilder();
@@ -99,7 +99,7 @@ public class EndToEndIntTest extends BaseIntTest {
     Consumer<ConsumerRecord<String, String>> messageCounter = cr -> ExceptionUtils.doUnchecked(() -> {
       TestEvent receivedEvent = objectMapper.readValue(cr.value(), TestEvent.class);
       if (receivedEvent.getMessage().equals(message)) {
-        assertThat(cr.headers().toArray().length).isEqualTo(1);
+        assertThat(cr.headers().toArray()).hasSize(1);
         org.apache.kafka.common.header.Header header = cr.headers().toArray()[0];
         assertThat(header.key()).isEqualTo("x-tw-criticality");
         assertThat(new String(header.value(), StandardCharsets.UTF_8)).isEqualTo("PrettyLowLol");
@@ -130,7 +130,7 @@ public class EndToEndIntTest extends BaseIntTest {
   }
 
   @Test
-  public void testExactlyOnceDelivery() throws Exception {
+  void testExactlyOnceDelivery() throws Exception {
     String message = "Hello World!";
     int threadsCount = 20;
     int batchesCount = 20;
@@ -206,7 +206,7 @@ public class EndToEndIntTest extends BaseIntTest {
   }
 
   @Test
-  public void testThatMessagesWithSameKeyEndUpInOnePartition() throws Exception {
+  void testThatMessagesWithSameKeyEndUpInOnePartition() throws Exception {
     String message = "Hello World!";
     String key = "GrailsRocks";
     int n = 20;
@@ -239,7 +239,7 @@ public class EndToEndIntTest extends BaseIntTest {
   }
 
   @Test
-  public void testThatMessagesWithSamePartitionEndUpInOnePartition() throws Exception {
+  void testThatMessagesWithSamePartitionEndUpInOnePartition() throws Exception {
     String message = "Hello World!";
     int partition = 3;
     int n = 20;
@@ -275,7 +275,7 @@ public class EndToEndIntTest extends BaseIntTest {
   }
 
   @Test
-  public void testThatMessagesOrderForAnEntityIsPreserved() throws Exception {
+  void testThatMessagesOrderForAnEntityIsPreserved() throws Exception {
     String message = "Hello World!";
     int entitiesCount = 100;
     int entityEventsCount = 100;
@@ -337,14 +337,14 @@ public class EndToEndIntTest extends BaseIntTest {
 
   @Test
   @SneakyThrows
-  public void sendingToUnknownTopicWillBePreventedWhenTopicAutoCreationIsDisabled() {
+  void sendingToUnknownTopicWillBePreventedWhenTopicAutoCreationIsDisabled() {
     assertThatThrownBy(() -> transactionalKafkaMessageSender
         .sendMessage(new TkmsMessage().setTopic("NotExistingTopic").setValue("Stuff".getBytes(StandardCharsets.UTF_8))))
         .hasMessageContaining("Topic NotExistingTopic not present in metadata");
   }
 
   @Test
-  public void sendingMultipleMessagesWorks() {
+  void sendingMultipleMessagesWorks() {
     byte[] value = "{\"message\" : \"Hello World!\"}".getBytes(StandardCharsets.UTF_8);
 
     AtomicInteger receivedCount = new AtomicInteger();
@@ -364,7 +364,7 @@ public class EndToEndIntTest extends BaseIntTest {
     assertThat(sendMessagesResult.getResults().size()).isEqualTo(4);
     assertThat(sendMessagesResult.getResults().get(1).getStorageId()).isNotNull();
     assertThat(sendMessagesResult.getResults().get(1).getShardPartition().getShard()).isEqualTo(1);
-    assertThat(sendMessagesResult.getResults().get(2).getShardPartition().getShard()).isEqualTo(0);
+    assertThat(sendMessagesResult.getResults().get(2).getShardPartition().getShard()).isZero();
 
     try {
       await().until(() -> receivedCount.get() == 4);
@@ -383,7 +383,7 @@ public class EndToEndIntTest extends BaseIntTest {
   }
 
   @Test
-  public void testThatSendingLargeMessagesWillNotCauseAnIssue() {
+  void testThatSendingLargeMessagesWillNotCauseAnIssue() {
     StringBuilder sb = new StringBuilder();
     // We generate message as large as maximum allowed bytes but this is set up to fail, as there is additional information
     // added by kafka producer.
@@ -438,7 +438,7 @@ public class EndToEndIntTest extends BaseIntTest {
    * If `TkmsStorageToKafkaProxy has some important lines switched around "lastId" logic, the test will start failing.
    */
   @Test
-  public void testThatTemporaryDeleteFailureDoesNotLeaveTrashBehind() throws Exception {
+  void testThatTemporaryDeleteFailureDoesNotLeaveTrashBehind() throws Exception {
     String message = "Hello World!";
     int messagesCount = 1000;
 
@@ -509,7 +509,7 @@ public class EndToEndIntTest extends BaseIntTest {
 
   @ParameterizedTest
   @MethodSource("compressionInput")
-  public void testMessageIsCompressed(CompressionAlgorithm algorithm, int expectedSerializedSize) throws Exception {
+  void testMessageIsCompressed(CompressionAlgorithm algorithm, int expectedSerializedSize) throws Exception {
     var message = StringUtils.repeat("Hello World!", 100);
 
     AtomicInteger receivedCount = new AtomicInteger();

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
@@ -522,7 +522,7 @@ public class EndToEndIntTest extends BaseIntTest {
       }
     });
 
-    Counter counter = meterRegistry.find(TkmsMetricsTemplate.SERIALIZED_SIZE_BYTES).tag("algorithm", algorithm.name().toLowerCase()).counter();
+    Counter counter = meterRegistry.find(TkmsMetricsTemplate.DAO_SERIALIZED_SIZE_BYTES).tag("algorithm", algorithm.name().toLowerCase()).counter();
     double startingSerializedSizeBytes = counter == null ? 0 : counter.count();
 
     testMessagesListener.registerConsumer(messageCounter);
@@ -535,7 +535,7 @@ public class EndToEndIntTest extends BaseIntTest {
 
       await().until(() -> receivedCount.get() > 0);
 
-      assertThat(meterRegistry.find(TkmsMetricsTemplate.SERIALIZED_SIZE_BYTES).tag("algorithm", algorithm.name().toLowerCase()).counter().count()
+      assertThat(meterRegistry.find(TkmsMetricsTemplate.DAO_SERIALIZED_SIZE_BYTES).tag("algorithm", algorithm.name().toLowerCase()).counter().count()
           - startingSerializedSizeBytes).isEqualTo(expectedSerializedSize);
 
       log.info("Messages received: " + receivedCount.get());

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MessagesInterceptionTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MessagesInterceptionTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Slf4j
-public class MessagesInterceptionTest extends BaseIntTest {
+class MessagesInterceptionTest extends BaseIntTest {
 
   @Autowired
   private TestMessagesInterceptor testMessagesInterceptor;

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MetricsTemplateIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MetricsTemplateIntTest.java
@@ -7,7 +7,7 @@ import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class MetricsTemplateIntTest extends BaseIntTest {
+class MetricsTemplateIntTest extends BaseIntTest {
 
   @Autowired
   private ITkmsMetricsTemplate metricsTemplate;

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
@@ -1,5 +1,7 @@
 package com.transferwise.kafka.tkms;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.transferwise.kafka.tkms.test.BaseIntTest;
 import io.micrometer.core.instrument.Gauge;
 import org.awaitility.Awaitility;
@@ -31,5 +33,16 @@ class MonitoringIntTest extends BaseIntTest {
       Gauge gauge = meterRegistry.find("tw.tkms.dao.rows.in.index.stats").tags("shard", "1", "partition", "0").gauge();
       return gauge != null && gauge.value() == 1_000_000;
     });
+  }
+
+  @Test
+  void earliestMessageIdIsRegistered() {
+    Awaitility.await().until(() -> {
+      Gauge gauge = meterRegistry.find("tw.tkms.dao.earliest.message.id").tags("shard", "1", "partition", "0").gauge();
+      return gauge != null;
+    });
+
+    assertThat(meterRegistry.find("tw.tkms.dao.earliest.message.id").tags("shard", "0", "partition", "0").gauge())
+        .as("Earliest message id tracking is not enabled for shard 0.").isNull();
   }
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
@@ -5,8 +5,8 @@ import io.micrometer.core.instrument.Gauge;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
-public class MonitoringIntTest extends BaseIntTest {
-  
+class MonitoringIntTest extends BaseIntTest {
+
   @Test
   void testThatMonitoringMetricsArePresent() {
     Awaitility.await().until(() -> {

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
@@ -1,0 +1,35 @@
+package com.transferwise.kafka.tkms;
+
+import com.transferwise.kafka.tkms.test.BaseIntTest;
+import io.micrometer.core.instrument.Gauge;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+public class MonitoringIntTest extends BaseIntTest {
+  
+  @Test
+  void testThatMonitoringMetricsArePresent() {
+    Awaitility.await().until(() -> {
+      Gauge gauge = meterRegistry.find("tw.tkms.dao.approximate.messages.count").tags("shard", "0", "partition", "0").gauge();
+      return gauge != null && gauge.value() >= 0;
+    });
+
+    Awaitility.await().until(() -> {
+      Gauge gauge = meterRegistry.find("tw.tkms.dao.approximate.messages.count").tags("shard", "1", "partition", "0").gauge();
+      return gauge != null && gauge.value() >= 0;
+    });
+  }
+
+  @Test
+  void testThatTableStatsMetricsArePresent() {
+    Awaitility.await().until(() -> {
+      Gauge gauge = meterRegistry.find("tw.tkms.dao.rows.in.table.stats").tags("shard", "1", "partition", "0").gauge();
+      return gauge != null && gauge.value() == 1_000_000;
+    });
+
+    Awaitility.await().until(() -> {
+      Gauge gauge = meterRegistry.find("tw.tkms.dao.rows.in.index.stats").tags("shard", "1", "partition", "0").gauge();
+      return gauge != null && gauge.value() == 1_000_000;
+    });
+  }
+}

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/PostgresMonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/PostgresMonitoringIntTest.java
@@ -1,0 +1,18 @@
+package com.transferwise.kafka.tkms;
+
+import io.micrometer.core.instrument.Gauge;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles(profiles = {"test", "postgres"})
+public class PostgresMonitoringIntTest extends MonitoringIntTest {
+
+  @Test
+  void testThatTableStatsMetricsArePresent() {
+    Awaitility.await().until(() -> {
+      Gauge gauge = meterRegistry.find("tw.tkms.dao.rows.in.table.stats").tags("shard", "1", "partition", "0").gauge();
+      return gauge != null && gauge.value() == 1_000_000;
+    });
+  }
+}

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/TkmsMessageValidationIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/TkmsMessageValidationIntTest.java
@@ -9,13 +9,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @BaseTestEnvironment
-public class TkmsMessageValidationIntTest {
+class TkmsMessageValidationIntTest {
 
   @Autowired
   private ITransactionalKafkaMessageSender transactionalKafkaMessageSender;
 
   @Test
-  public void invalidMessagesDoNotPassValidation() {
+  void invalidMessagesDoNotPassValidation() {
     assertThatThrownBy(() -> transactionalKafkaMessageSender.sendMessage(new TkmsMessage())).isInstanceOf(IllegalArgumentException.class)
         .hasMessage("0: No topic provided.");
   }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/config/TkmsKafkaProducerProviderTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/config/TkmsKafkaProducerProviderTest.java
@@ -9,16 +9,15 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class TkmsKafkaProducerProviderTest extends BaseIntTest {
+class TkmsKafkaProducerProviderTest extends BaseIntTest {
 
   @Autowired
   private ITkmsKafkaProducerProvider tkmsKafkaProducerProvider;
 
   @Test
-  public void shardKafkaPropertiesAreApplied() throws Exception {
+  void shardKafkaPropertiesAreApplied() throws Exception {
     KafkaProducer<String, byte[]> kafkaProducer = tkmsKafkaProducerProvider.getKafkaProducer(1);
 
-    
     Field producerConfigField = kafkaProducer.getClass().getDeclaredField("producerConfig");
     producerConfigField.setAccessible(true);
     ProducerConfig producerConfig = (ProducerConfig) producerConfigField.get(kafkaProducer);

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/FaultInjectedTkmsDao.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/FaultInjectedTkmsDao.java
@@ -28,8 +28,13 @@ public class FaultInjectedTkmsDao implements ITkmsDao {
   }
 
   @Override
-  public List<MessageRecord> getMessages(TkmsShardPartition shardPartition, int maxCount) {
-    return delegate.getMessages(shardPartition, maxCount);
+  public long getApproximateMessagesCount(TkmsShardPartition sp) {
+    return delegate.getApproximateMessagesCount(sp);
+  }
+
+  @Override
+  public List<MessageRecord> getMessages(TkmsShardPartition shardPartition, long earliestMessageId, int maxCount) {
+    return delegate.getMessages(shardPartition, earliestMessageId, maxCount);
   }
 
   @Override
@@ -40,4 +45,20 @@ public class FaultInjectedTkmsDao implements ITkmsDao {
       delegate.deleteMessages(shardPartition, records);
     }
   }
+
+  @Override
+  public Long getEarliestMessageId(TkmsShardPartition shardPartition) {
+    return delegate.getEarliestMessageId(shardPartition);
+  }
+
+  @Override
+  public void saveEarliestMessageId(TkmsShardPartition shardPartition, long messageId) {
+    delegate.saveEarliestMessageId(shardPartition, messageId);
+  }
+
+  @Override
+  public boolean insertEarliestMessageId(TkmsShardPartition shardPartition) {
+    return delegate.insertEarliestMessageId(shardPartition);
+  }
+  
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/FaultInjectedTkmsDao.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/FaultInjectedTkmsDao.java
@@ -33,6 +33,11 @@ public class FaultInjectedTkmsDao implements ITkmsDao {
   }
 
   @Override
+  public boolean hasMessagesBeforeId(TkmsShardPartition sp, Long messageId) {
+    return delegate.hasMessagesBeforeId(sp, messageId);
+  }
+
+  @Override
   public List<MessageRecord> getMessages(TkmsShardPartition shardPartition, long earliestMessageId, int maxCount) {
     return delegate.getMessages(shardPartition, earliestMessageId, maxCount);
   }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/FaultInjectedTkmsDao.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/FaultInjectedTkmsDao.java
@@ -60,5 +60,5 @@ public class FaultInjectedTkmsDao implements ITkmsDao {
   public boolean insertEarliestMessageId(TkmsShardPartition shardPartition) {
     return delegate.insertEarliestMessageId(shardPartition);
   }
-  
+
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/PostgresTkmsDaoIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/PostgresTkmsDaoIntTest.java
@@ -1,0 +1,11 @@
+package com.transferwise.kafka.tkms.dao;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.test.context.ActiveProfiles;
+
+@TestInstance(Lifecycle.PER_CLASS)
+@ActiveProfiles(profiles = {"test", "postgres"})
+class PostgresTkmsDaoIntTest extends TkmsDaoIntTest {
+
+}

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/TkmsDaoIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/TkmsDaoIntTest.java
@@ -21,7 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 @TestInstance(Lifecycle.PER_CLASS)
-public class TkmsDaoIntTest extends BaseIntTest {
+class TkmsDaoIntTest extends BaseIntTest {
 
   @Autowired
   private ITkmsDao tkmsDao;
@@ -63,6 +63,6 @@ public class TkmsDaoIntTest extends BaseIntTest {
     assertThat(meterRegistry.get("tw.tkms.dao.messages.delete").tags("batchSize", "4").counter().count()).isEqualTo(2);
     assertThat(meterRegistry.get("tw.tkms.dao.messages.delete").tags("batchSize", "1").counter().count()).isEqualTo(1);
 
-    assertThat(new JdbcTemplate(dataSource).queryForObject("select count(*) from outgoing_message_0_0", Integer.class)).isEqualTo(0);
+    assertThat(new JdbcTemplate(dataSource).queryForObject("select count(*) from outgoing_message_0_0", Integer.class)).isZero();
   }
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/BaseIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/BaseIntTest.java
@@ -1,7 +1,9 @@
 package com.transferwise.kafka.tkms.test;
 
 import com.transferwise.common.baseutils.meters.cache.IMeterCache;
-import com.transferwise.common.baseutils.meters.cache.MeterCache;
+import com.transferwise.kafka.tkms.TkmsClockHolder;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +19,7 @@ public class BaseIntTest {
 
   @Autowired
   protected MeterRegistry meterRegistry;
-  
+
   @Autowired
   protected IMeterCache meterCache;
 
@@ -25,7 +27,14 @@ public class BaseIntTest {
   public void cleanup() {
     tkmsRegisteredMessagesCollector.clear();
     tkmsSentMessagesCollector.clear();
-    meterRegistry.clear();
+
+    for (Meter meter : meterRegistry.getMeters()) {
+      if (!(meter instanceof Gauge)) {
+        meterRegistry.remove(meter);
+      }
+    }
     meterCache.clear();
+
+    TkmsClockHolder.reset();
   }
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/BaseIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/BaseIntTest.java
@@ -7,6 +7,7 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 @BaseTestEnvironment
 public class BaseIntTest {
@@ -22,6 +23,9 @@ public class BaseIntTest {
 
   @Autowired
   protected IMeterCache meterCache;
+  
+  @Autowired
+  protected JdbcTemplate jdbcTemplate;
 
   @AfterEach
   public void cleanup() {

--- a/tw-tkms-starter/src/test/java/db/migration/earliestmessage/V2__Init.java
+++ b/tw-tkms-starter/src/test/java/db/migration/earliestmessage/V2__Init.java
@@ -1,0 +1,35 @@
+package db.migration.earliestmessage;
+
+import java.sql.Statement;
+import lombok.extern.slf4j.Slf4j;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+@Slf4j
+public class V2__Init extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    for (int s = 0; s < 5; s++) {
+      for (int p = 0; p < 10; p++) {
+        try (Statement stmt = context.getConnection().createStatement()) {
+          String tableName = "earliestmessage.outgoing_message_" + s + "_" + p;
+          stmt.execute("CREATE TABLE " + tableName + " (\n"
+              + "  id BIGSERIAL PRIMARY KEY,\n"
+              + "  message BYTEA NOT NULL\n"
+              + ") WITH (autovacuum_analyze_threshold=1000000000, autovacuum_vacuum_threshold=100000, toast_tuple_target=8160) ");
+          log.info("Create table `" + tableName + "'.");
+
+          stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN id SET (n_distinct=1000000);");
+          stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN message SET STORAGE EXTERNAL");
+          stmt.executeUpdate("VACUUM FULL " + tableName);
+        }
+      }
+    }
+  }
+
+  @Override
+  public boolean canExecuteInTransaction() {
+    return false;
+  }
+}

--- a/tw-tkms-starter/src/test/resources/application.yml
+++ b/tw-tkms-starter/src/test/resources/application.yml
@@ -87,13 +87,14 @@ spring:
     default-schema: "earliestmessage"
     schemas:
       - "earliestmessage"
+
 tw-tkms:
   database-dialect: POSTGRES
   earliest-visible-messages:
     enabled: true
     look-back-period: 10
     table-name: earliestmessage.tw_tkms_earliest_visible_messages 
-  shards-count: 1
+  shards-count: 2
   table-base-name: earliestmessage.outgoing_message
   monitoring:
     left-over-messages-check-start-delay: 1s

--- a/tw-tkms-starter/src/test/resources/application.yml
+++ b/tw-tkms-starter/src/test/resources/application.yml
@@ -73,3 +73,28 @@ tw-tkms:
 
 tw-tkms-test:
   test-topic: TestTopicPostgres
+
+---
+
+spring:
+  profiles: earliest-message
+  application.name: tw-tkms-earliest-message
+  datasource:
+    url: "jdbc:postgresql://localhost:${POSTGRES_TCP_5432}/postgres"
+    username: "postgres"
+  flyway:
+    locations: "classpath:db/migration/earliestmessage"
+    default-schema: "earliestmessage"
+    schemas:
+      - "earliestmessage"
+tw-tkms:
+  database-dialect: POSTGRES
+  earliest-visible-messages:
+    enabled: true
+    look-back-period: 10
+    table-name: earliestmessage.tw_tkms_earliest_visible_messages 
+  shards-count: 1
+  table-base-name: earliestmessage.outgoing_message
+    
+tw-tkms-test:
+  test-topic: TestTopicEarliestMessage

--- a/tw-tkms-starter/src/test/resources/application.yml
+++ b/tw-tkms-starter/src/test/resources/application.yml
@@ -95,6 +95,8 @@ tw-tkms:
     table-name: earliestmessage.tw_tkms_earliest_visible_messages 
   shards-count: 1
   table-base-name: earliestmessage.outgoing_message
+  monitoring:
+    left-over-messages-check-start-delay: 1s
     
 tw-tkms-test:
   test-topic: TestTopicEarliestMessage

--- a/tw-tkms-starter/src/test/resources/application.yml
+++ b/tw-tkms-starter/src/test/resources/application.yml
@@ -38,12 +38,16 @@ tw-tkms:
       kafka:
         linger:
           ms: 7
+      earliest-visible-messages:
+        enabled: true
   debug-enabled: true
   compression:
     algorithm: random
     min-size: 10
   environment:
     previous-version: 0.7.3
+  monitoring:
+    start-delay: 0s
 
 tw-graceful-shutdown:
   clients-reaction-time-ms: 1000
@@ -66,5 +70,6 @@ spring:
 
 tw-tkms:
   database-dialect: POSTGRES
+
 tw-tkms-test:
   test-topic: TestTopicPostgres

--- a/tw-tkms-starter/src/test/resources/db/migration/earliestmessage/V1__earliest_message_schema.sql
+++ b/tw-tkms-starter/src/test/resources/db/migration/earliestmessage/V1__earliest_message_schema.sql
@@ -1,0 +1,1 @@
+CREATE schema if not exists earliestmessage;

--- a/tw-tkms-starter/src/test/resources/db/migration/earliestmessage/V3__earliest_message_table.sql
+++ b/tw-tkms-starter/src/test/resources/db/migration/earliestmessage/V3__earliest_message_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE earliestmessage.tw_tkms_earliest_visible_messages
+(
+    shard      BIGINT NOT NULL,
+    part       BIGINT NOT NULL,
+    message_id BIGINT NOT NULL,
+    PRIMARY KEY (shard, part)
+) 

--- a/tw-tkms-starter/src/test/resources/db/migration/mysql/V2__earliest_visible_message.sql
+++ b/tw-tkms-starter/src/test/resources/db/migration/mysql/V2__earliest_visible_message.sql
@@ -1,0 +1,7 @@
+CREATE TABLE tw_tkms_earliest_visible_messages
+(
+    shard      BIGINT NOT NULL,
+    part       BIGINT NOT NULL,
+    message_id BIGINT NOT NULL,
+    PRIMARY KEY (shard, part)
+) 

--- a/tw-tkms-starter/src/test/resources/db/migration/postgres/V2__earliest_visible_message.sql
+++ b/tw-tkms-starter/src/test/resources/db/migration/postgres/V2__earliest_visible_message.sql
@@ -1,0 +1,7 @@
+CREATE TABLE tw_tkms_earliest_visible_messages
+(
+    shard      BIGINT NOT NULL,
+    part       BIGINT NOT NULL,
+    message_id BIGINT NOT NULL,
+    PRIMARY KEY (shard, part)
+) 

--- a/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/ITkmsTestDao.java
+++ b/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/ITkmsTestDao.java
@@ -3,5 +3,6 @@ package com.transferwise.kafka.tkms.test;
 import com.transferwise.kafka.tkms.api.TkmsShardPartition;
 
 public interface ITkmsTestDao {
+
   int getMessagesCount(TkmsShardPartition shardPartition);
 }

--- a/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/TkmsRegisteredMessagesCollector.java
+++ b/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/TkmsRegisteredMessagesCollector.java
@@ -33,7 +33,7 @@ public class TkmsRegisteredMessagesCollector implements ITkmsRegisteredMessagesC
           "Collected " + messagesCount.get() + " messages, while the limit is " + tkmsTestProperties.getMaxCollectedMessages());
     }
     messagesCount.incrementAndGet();
-    messages.computeIfAbsent(event.getMessage().getTopic(), (k) -> Collections.synchronizedMap(new LinkedHashMap<>()))
+    messages.computeIfAbsent(event.getMessage().getTopic(), k -> Collections.synchronizedMap(new LinkedHashMap<>()))
         .put(Pair.of(event.getShardPartition(), event.getStorageId()),
             new RegisteredMessage().setShardPartition(event.getShardPartition()).setStorageId(event.getStorageId()).setMessage(event.getMessage()));
   }

--- a/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/TkmsSentMessagesCollector.java
+++ b/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/TkmsSentMessagesCollector.java
@@ -33,7 +33,7 @@ public class TkmsSentMessagesCollector implements ITkmsSentMessagesCollector, IT
           "Full. Collected " + messagesCount.get() + " messages, while the limit is " + tkmsTestProperties.getMaxCollectedMessages());
     }
     messagesCount.incrementAndGet();
-    messages.computeIfAbsent(event.getProducerRecord().topic(), (k) -> Collections.synchronizedMap(new LinkedHashMap<>()))
+    messages.computeIfAbsent(event.getProducerRecord().topic(), k -> Collections.synchronizedMap(new LinkedHashMap<>()))
         .put(Pair.of(event.getShardPartition(), event.getStorageId()),
             new SentMessage().setShardPartition(event.getShardPartition()).setStorageId(event.getStorageId())
                 .setProducerRecord(event.getProducerRecord()));

--- a/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/TkmsTestProperties.java
+++ b/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/TkmsTestProperties.java
@@ -6,5 +6,6 @@ import lombok.experimental.Accessors;
 @Data
 @Accessors(chain = true)
 public class TkmsTestProperties {
+
   private int maxCollectedMessages = 100_000;
 }


### PR DESCRIPTION
## Context

Massive amount of dead tuples on Postgres can make tw-tkms slow and overload the database.

### Changes

Handling a case, where Postgres database has long running transactions preventing dead tuples being cleared for tw-tkms tables.

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
