### PR TITLE
feat: bump protobuf to 3.20.1

### DIFF
--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,5 +1,5 @@
 ext {
-    protobufVersion = "3.18.0"
+    protobufVersion = "3.20.1"
     libraries = [
             // version defined
             awaitility                      : 'org.awaitility:awaitility:4.1.1',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.14.4
+version=0.15.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.14.3
+version=0.14.4


### PR DESCRIPTION
## Context

Bump protobuf version to 3.20.x. It fixes [CVE-2021-22569](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22569).

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
