### PR TITLE
adding KafkaProducer metrics to have the same metrics as with Spring Kafka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2022-10-12
+### Added
+* Adding Kafka Producer metrics using Micrometer.
+
+
 ## [0.15.0] - 2022-05-28
 ### Changed
 * Update protobuf version from 3.18.0 to 3.20.1 in order to fix CVE-2021-22569.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.15.0
+version=0.16.0

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsKafkaProducerProvider.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsKafkaProducerProvider.java
@@ -2,13 +2,12 @@ package com.transferwise.kafka.tkms.config;
 
 import com.transferwise.common.gracefulshutdown.GracefulShutdownStrategy;
 import com.transferwise.kafka.tkms.config.TkmsProperties.ShardProperties;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsKafkaProducerProvider.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsKafkaProducerProvider.java
@@ -6,6 +6,9 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -19,7 +22,12 @@ public class TkmsKafkaProducerProvider implements ITkmsKafkaProducerProvider, Gr
   @Autowired
   private TkmsProperties tkmsProperties;
 
+  @Autowired
+  private MeterRegistry meterRegistry;
+
   private Map<Integer, KafkaProducer<String, byte[]>> kafkaProducers = new ConcurrentHashMap<>();
+
+  private Map<Integer, KafkaClientMetrics> kafkaClientMetrics = new HashMap<>();
 
   @Override
   public KafkaProducer<String, byte[]> getKafkaProducer(int shard) {
@@ -45,12 +53,20 @@ public class TkmsKafkaProducerProvider implements ITkmsKafkaProducerProvider, Gr
         configs.putAll(shardProperties.getKafka());
       }
 
-      return new KafkaProducer<>(configs);
+      KafkaProducer<String, byte[]> kafkaProducer = new KafkaProducer<>(configs);
+      kafkaClientMetrics.put(shard, new KafkaClientMetrics(kafkaProducer));
+      kafkaClientMetrics.get(shard).bindTo(meterRegistry);
+      return kafkaProducer;
     });
   }
 
   @Override
   public void closeKafkaProducer(int shard) {
+    KafkaClientMetrics kafkaClientMetric = kafkaClientMetrics.remove(shard);
+    if (kafkaClientMetric != null) {
+      kafkaClientMetric.close();
+    }
+
     KafkaProducer<String, byte[]> producer = kafkaProducers.remove(shard);
     if (producer != null) {
       try {
@@ -64,6 +80,11 @@ public class TkmsKafkaProducerProvider implements ITkmsKafkaProducerProvider, Gr
   @Override
   public void applicationTerminating() {
     kafkaProducers.forEach((shard, producer) -> {
+      KafkaClientMetrics kafkaClientMetric = kafkaClientMetrics.remove(shard);
+      if (kafkaClientMetric != null) {
+        kafkaClientMetric.close();
+      }
+
       try {
         producer.close(Duration.ofSeconds(5));
       } catch (Throwable t) {

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/KafkaMetricsIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/KafkaMetricsIntTest.java
@@ -1,0 +1,85 @@
+package com.transferwise.kafka.tkms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.transferwise.common.baseutils.ExceptionUtils;
+import com.transferwise.kafka.tkms.api.ITransactionalKafkaMessageSender;
+import com.transferwise.kafka.tkms.api.TkmsMessage;
+import com.transferwise.kafka.tkms.test.BaseTestEnvironment;
+import com.transferwise.kafka.tkms.test.ITkmsRegisteredMessagesCollector;
+import com.transferwise.kafka.tkms.test.ITkmsSentMessagesCollector;
+import com.transferwise.kafka.tkms.test.TestMessagesListener;
+import com.transferwise.kafka.tkms.test.TestProperties;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@BaseTestEnvironment
+public class KafkaMetricsIntTest {
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private ITransactionalKafkaMessageSender transactionalKafkaMessageSender;
+
+  @Autowired
+  private TestMessagesListener testMessagesListener;
+
+  @Autowired
+  private TestProperties testProperties;
+
+  @Autowired
+  protected ITkmsRegisteredMessagesCollector tkmsRegisteredMessagesCollector;
+
+  @Autowired
+  protected ITkmsSentMessagesCollector tkmsSentMessagesCollector;
+
+  @Autowired
+  protected MeterRegistry meterRegistry;
+
+  @AfterEach
+  public void cleanup() {
+    tkmsRegisteredMessagesCollector.clear();
+    tkmsSentMessagesCollector.clear();
+
+    TkmsClockHolder.reset();
+  }
+
+  @Test
+  void testThatProducerMetricShowsSentMessage() throws Exception {
+
+    String message = "Hello World!";
+
+    AtomicInteger receivedCount = new AtomicInteger();
+    Consumer<ConsumerRecord<String, String>> messageCounter = cr -> ExceptionUtils.doUnchecked(() -> {
+      TestMessagesListener.TestEvent receivedEvent = objectMapper.readValue(cr.value(), TestMessagesListener.TestEvent.class);
+      if (receivedEvent.getMessage().equals(message)) {
+        receivedCount.incrementAndGet();
+      } else {
+        throw new IllegalStateException("Wrong message receive: " + receivedEvent.getMessage());
+      }
+    });
+
+    testMessagesListener.registerConsumer(messageCounter);
+    try {
+      TestMessagesListener.TestEvent testEvent = new TestMessagesListener.TestEvent().setId(1L).setMessage(message);
+
+      transactionalKafkaMessageSender
+        .sendMessage(new TkmsMessage().setTopic(testProperties.getTestTopic()).setValue(objectMapper.writeValueAsBytes(testEvent)));
+
+      await().until(() -> receivedCount.get() > 0);
+
+    } finally {
+      testMessagesListener.unregisterConsumer(messageCounter);
+    }
+
+    assertThat(meterRegistry.find("kafka.producer.record.send.total").tags().functionCounter().count())
+      .as("Producer's metric shows one message sent.").isGreaterThan(0L);
+  }
+}

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
@@ -1,20 +1,14 @@
 package com.transferwise.kafka.tkms;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.transferwise.common.baseutils.ExceptionUtils;
 import com.transferwise.kafka.tkms.api.ITransactionalKafkaMessageSender;
-import com.transferwise.kafka.tkms.api.TkmsMessage;
 import com.transferwise.kafka.tkms.test.BaseIntTest;
 import com.transferwise.kafka.tkms.test.TestMessagesListener;
 import com.transferwise.kafka.tkms.test.TestProperties;
 import io.micrometer.core.instrument.Gauge;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,41 +60,6 @@ class MonitoringIntTest extends BaseIntTest {
 
     assertThat(meterRegistry.find("tw.tkms.dao.earliest.message.id").tags("shard", "0", "partition", "0").gauge())
         .as("Earliest message id tracking is not enabled for shard 0.").isNull();
-  }
-
-  @Test
-  void testThatProducerMetricShowsSentMessage() throws Exception {
-
-    String message = "Hello World!";
-
-    AtomicInteger receivedCount = new AtomicInteger();
-    Consumer<ConsumerRecord<String, String>> messageCounter = cr -> ExceptionUtils.doUnchecked(() -> {
-      TestMessagesListener.TestEvent receivedEvent = objectMapper.readValue(cr.value(), TestMessagesListener.TestEvent.class);
-      if (receivedEvent.getMessage().equals(message)) {
-        receivedCount.incrementAndGet();
-      } else {
-        throw new IllegalStateException("Wrong message receive: " + receivedEvent.getMessage());
-      }
-    });
-
-    testMessagesListener.registerConsumer(messageCounter);
-    try {
-      TestMessagesListener.TestEvent testEvent = new TestMessagesListener.TestEvent().setId(1L).setMessage(message);
-
-      transactionalKafkaMessageSender
-              .sendMessage(new TkmsMessage().setTopic(testProperties.getTestTopic()).setValue(objectMapper.writeValueAsBytes(testEvent)));
-
-      await().until(() -> receivedCount.get() > 0);
-
-    } finally {
-      testMessagesListener.unregisterConsumer(messageCounter);
-    }
-
-    assertThat(meterRegistry.find("kafka.producer.record.send.total")
-                .tags("client.id", "producer-1", "kafka.version", "2.7.2")
-                .functionCounter().count())
-            .as("Producer's metric shows one message sent.")
-            .isEqualTo(1L);
   }
 
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
@@ -1,13 +1,36 @@
 package com.transferwise.kafka.tkms;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.transferwise.common.baseutils.ExceptionUtils;
+import com.transferwise.kafka.tkms.api.ITransactionalKafkaMessageSender;
+import com.transferwise.kafka.tkms.api.TkmsMessage;
 import com.transferwise.kafka.tkms.test.BaseIntTest;
+import com.transferwise.kafka.tkms.test.TestMessagesListener;
+import com.transferwise.kafka.tkms.test.TestProperties;
 import io.micrometer.core.instrument.Gauge;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+@Slf4j
 class MonitoringIntTest extends BaseIntTest {
+
+  @Autowired
+  private ObjectMapper objectMapper;
+  @Autowired
+  private ITransactionalKafkaMessageSender transactionalKafkaMessageSender;
+  @Autowired
+  private TestMessagesListener testMessagesListener;
+  @Autowired
+  private TestProperties testProperties;
 
   @Test
   void testThatMonitoringMetricsArePresent() {
@@ -45,4 +68,37 @@ class MonitoringIntTest extends BaseIntTest {
     assertThat(meterRegistry.find("tw.tkms.dao.earliest.message.id").tags("shard", "0", "partition", "0").gauge())
         .as("Earliest message id tracking is not enabled for shard 0.").isNull();
   }
+
+  @Test
+  void testThatProducerMetricShowsSentMessage() throws Exception {
+
+    String message = "Hello World!";
+
+    AtomicInteger receivedCount = new AtomicInteger();
+    Consumer<ConsumerRecord<String, String>> messageCounter = cr -> ExceptionUtils.doUnchecked(() -> {
+      TestMessagesListener.TestEvent receivedEvent = objectMapper.readValue(cr.value(), TestMessagesListener.TestEvent.class);
+      if (receivedEvent.getMessage().equals(message)) {
+        receivedCount.incrementAndGet();
+      } else {
+        throw new IllegalStateException("Wrong message receive: " + receivedEvent.getMessage());
+      }
+    });
+
+    testMessagesListener.registerConsumer(messageCounter);
+    try {
+      TestMessagesListener.TestEvent testEvent = new TestMessagesListener.TestEvent().setId(1L).setMessage(message);
+
+      transactionalKafkaMessageSender
+              .sendMessage(new TkmsMessage().setTopic(testProperties.getTestTopic()).setValue(objectMapper.writeValueAsBytes(testEvent)));
+
+      await().until(() -> receivedCount.get() > 0);
+
+    } finally {
+      testMessagesListener.unregisterConsumer(messageCounter);
+    }
+
+    assertThat(meterRegistry.find("kafka.producer.record.send.total").tags("client.id", "producer-1", "kafka.version", "2.7.2").functionCounter().count())
+            .as("Producer's metric shows one message sent.").isEqualTo(1L);
+  }
+
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
@@ -2,28 +2,14 @@ package com.transferwise.kafka.tkms;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.transferwise.kafka.tkms.api.ITransactionalKafkaMessageSender;
 import com.transferwise.kafka.tkms.test.BaseIntTest;
-import com.transferwise.kafka.tkms.test.TestMessagesListener;
-import com.transferwise.kafka.tkms.test.TestProperties;
 import io.micrometer.core.instrument.Gauge;
 import lombok.extern.slf4j.Slf4j;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @Slf4j
 class MonitoringIntTest extends BaseIntTest {
-
-  @Autowired
-  private ObjectMapper objectMapper;
-  @Autowired
-  private ITransactionalKafkaMessageSender transactionalKafkaMessageSender;
-  @Autowired
-  private TestMessagesListener testMessagesListener;
-  @Autowired
-  private TestProperties testProperties;
 
   @Test
   void testThatMonitoringMetricsArePresent() {
@@ -61,5 +47,4 @@ class MonitoringIntTest extends BaseIntTest {
     assertThat(meterRegistry.find("tw.tkms.dao.earliest.message.id").tags("shard", "0", "partition", "0").gauge())
         .as("Earliest message id tracking is not enabled for shard 0.").isNull();
   }
-
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
@@ -11,14 +11,13 @@ import com.transferwise.kafka.tkms.test.BaseIntTest;
 import com.transferwise.kafka.tkms.test.TestMessagesListener;
 import com.transferwise.kafka.tkms.test.TestProperties;
 import io.micrometer.core.instrument.Gauge;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 
 @Slf4j
 class MonitoringIntTest extends BaseIntTest {
@@ -97,8 +96,11 @@ class MonitoringIntTest extends BaseIntTest {
       testMessagesListener.unregisterConsumer(messageCounter);
     }
 
-    assertThat(meterRegistry.find("kafka.producer.record.send.total").tags("client.id", "producer-1", "kafka.version", "2.7.2").functionCounter().count())
-            .as("Producer's metric shows one message sent.").isEqualTo(1L);
+    assertThat(meterRegistry.find("kafka.producer.record.send.total")
+                .tags("client.id", "producer-1", "kafka.version", "2.7.2")
+                .functionCounter().count())
+            .as("Producer's metric shows one message sent.")
+            .isEqualTo(1L);
   }
 
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
@@ -4,11 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.transferwise.kafka.tkms.test.BaseIntTest;
 import io.micrometer.core.instrument.Gauge;
-import lombok.extern.slf4j.Slf4j;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
-@Slf4j
 class MonitoringIntTest extends BaseIntTest {
 
   @Test

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/BaseIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/BaseIntTest.java
@@ -33,12 +33,16 @@ public class BaseIntTest {
     tkmsSentMessagesCollector.clear();
 
     for (Meter meter : meterRegistry.getMeters()) {
-      if (!(meter instanceof Gauge)) {
+      if (!(meter instanceof Gauge) && !(isKafkaProducerMeter(meter))) {
         meterRegistry.remove(meter);
       }
     }
     meterCache.clear();
 
     TkmsClockHolder.reset();
+  }
+
+  private boolean isKafkaProducerMeter(Meter meter) {
+    return meter.getId().getName().startsWith("kafka.producer.");
   }
 }


### PR DESCRIPTION
## Context

Enable the same KafkaProducer metrics as we already use for Spring Kafka based services.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
