### PR TITLE
APPENG-183: Spring Boot 2.7 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2022-11-10
+### Fixed
+* Class cast exception, when KeyHolder value is not a long (e.g. BigInteger). This happens with the latest maria driver on some db schemas.
+
 ## [0.16.0] - 2022-10-12
 ### Added
 * Adding Kafka Producer metrics using Micrometer.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*    @transferwise/central-sre
+*    @transferwise/application-engineering

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.16.0
+version=0.16.1

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
@@ -265,7 +265,7 @@ public class TkmsDao implements ITkmsDao {
 
   @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
   protected long keyToLong(KeyHolder keyHolder) {
-    return (long) keyHolder.getKey();
+    return keyHolder.getKey().longValue();
   }
 
   @Override


### PR DESCRIPTION
Fixing `ClassCastException`, when KeyHolder value is not a long (e.g. BigInteger). This happens with the latest maria driver on some db schemas.

## Context

After SB2.7 update, schema with bigInt columns can return an instance of BigInteger instead of long from KeyHolder.
Using `.longValue()` method works in those cases.

Also, change CODEOWNERS, as it's ours now 🗡️ 

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
