### PR TITLE
Distinct implementations for Maria & Postgres Dao

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ ij_formatter_tags_enabled = true
 ij_smart_tabs = false
 ij_wrap_on_typing = false
 
-[]
+[*]
 ij_continuation_indent_size = 2
 ij_proto_keep_indents_on_empty_lines = false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2022-11-28
+### Changed
+* Make TkmsDao abstract and provide two implementations TkmsMariaDao and TkmsPostgresDao.
+* Allow override of database dialect for a shard.
+
 ## [0.17.0] - 2022-11-28
 
 ### Changed
@@ -27,12 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.3] - 2021-12-10
 ### Changed
-* Removed explicit dependency on flyway beans, while making sure it's configured before tkms if provided. 
+* Removed explicit dependency on flyway beans, while making sure it's configured before tkms if provided.
 
 
 ## [0.14.2] - 2021-10-21
 ### Fixed
-* When table and index statistics validation fails, we log it as an error, but continue. 
+* When table and index statistics validation fails, we log it as an error, but continue.
 
 ## [0.14.1] - 2021-10-21
 ### Fixed
@@ -46,7 +51,7 @@ So while a team waits behind DBAs to add those privileges, they can temporarily 
 ## [0.14.0] - 2021-09-28
 ### Changed
 * Handling a case, where Postgres database has long running transactions, and those are preventing dead tuples being cleared for tw-tkms tables,
-  resulting in massive tw-tkms slow down and database overload. 
+  resulting in massive tw-tkms slow down and database overload.
   More detailed info [here](docs/postgres_with_long_transactions.md).
 
 ## [0.13.0] - 2021-05-31
@@ -93,7 +98,7 @@ It is most appropriate for typical Transferwise messages.
 ### Added
 * A mechanism to force specific migration paths.
 Service owner can specify which version is running in production by `TkmsProperties.Environment.previousVersion`.
-If the version is too old, the service will refuse to start. It can be fixed by doing upgrades to intermediate versions.  
+If the version is too old, the service will refuse to start. It can be fixed by doing upgrades to intermediate versions.
 
 * Metrics
 `tw_tkms_dao_serialization_original_size_bytes {shard, partition, algorithm}`
@@ -121,7 +126,7 @@ If the version is too old, the service will refuse to start. It can be fixed by 
 
 ## [0.6.2] - 2020-12-17
 ### Fixed
-* Registering a metric for failed kafka send resulted in error because of wrong set of tags being used. 
+* Registering a metric for failed kafka send resulted in error because of wrong set of tags being used.
 
 ## [0.6.1] - 2020-11-13
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.17.0
+version=0.18.0

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsConfiguration.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsConfiguration.java
@@ -2,17 +2,32 @@ package com.transferwise.kafka.tkms.config;
 
 import com.transferwise.common.baseutils.meters.cache.IMeterCache;
 import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHelper;
-import com.transferwise.kafka.tkms.*;
+import com.transferwise.kafka.tkms.EnvironmentValidator;
+import com.transferwise.kafka.tkms.IEnvironmentValidator;
+import com.transferwise.kafka.tkms.ITkmsPaceMaker;
+import com.transferwise.kafka.tkms.ITkmsStorageToKafkaProxy;
+import com.transferwise.kafka.tkms.ITkmsZookeeperOperations;
+import com.transferwise.kafka.tkms.TkmsMessageInterceptors;
+import com.transferwise.kafka.tkms.TkmsPaceMaker;
+import com.transferwise.kafka.tkms.TkmsStorageToKafkaProxy;
+import com.transferwise.kafka.tkms.TkmsZookeeperOperations;
+import com.transferwise.kafka.tkms.TransactionalKafkaMessageSender;
 import com.transferwise.kafka.tkms.api.ITkmsMessageInterceptors;
 import com.transferwise.kafka.tkms.api.ITransactionalKafkaMessageSender;
 import com.transferwise.kafka.tkms.api.Tkms;
 import com.transferwise.kafka.tkms.api.helpers.ITkmsMessageFactory;
 import com.transferwise.kafka.tkms.api.helpers.TkmsMessageFactory;
 import com.transferwise.kafka.tkms.config.TkmsProperties.DatabaseDialect;
-import com.transferwise.kafka.tkms.dao.*;
+import com.transferwise.kafka.tkms.dao.ITkmsDao;
+import com.transferwise.kafka.tkms.dao.ITkmsMessageSerializer;
+import com.transferwise.kafka.tkms.dao.TkmsDao;
+import com.transferwise.kafka.tkms.dao.TkmsMariaDao;
+import com.transferwise.kafka.tkms.dao.TkmsMessageSerializer;
+import com.transferwise.kafka.tkms.dao.TkmsPostgresDao;
 import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
 import com.transferwise.kafka.tkms.metrics.TkmsClusterWideStateMonitor;
 import com.transferwise.kafka.tkms.metrics.TkmsMetricsTemplate;
+import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -22,8 +37,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
-
-import javax.sql.DataSource;
 
 /**
  * Separated things here, which can be included in non spring-boot application without modification.

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -174,6 +174,7 @@ public class TkmsProperties {
   @Accessors(chain = true)
   public static class ShardProperties {
 
+    private DatabaseDialect databaseDialect;
     private Integer partitionsCount;
     private Integer pollerBatchSize;
     private Duration pollingInterval;
@@ -184,6 +185,14 @@ public class TkmsProperties {
     private EarliestVisibleMessages earliestVisibleMessages;
 
     private Map<String, String> kafka = new HashMap<>();
+  }
+
+  public DatabaseDialect getDatabaseDialect(int shard) {
+    ShardProperties shardProperties = shards.get(shard);
+    if (shardProperties != null && shardProperties.getDatabaseDialect() != null) {
+      return shardProperties.getDatabaseDialect();
+    }
+    return databaseDialect;
   }
 
   public int getPartitionsCount(int shard) {
@@ -289,7 +298,7 @@ public class TkmsProperties {
 
     private Duration interval = Duration.ofSeconds(30);
     private Duration startDelay = Duration.ofSeconds(30);
-    
+
     private Duration leftOverMessagesCheckInterval = Duration.ofHours(1);
     private Duration leftOverMessagesCheckStartDelay = Duration.ofHours(1);
   }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
@@ -16,83 +16,91 @@ import java.util.List;
 @Slf4j
 public class TkmsMariaDao extends TkmsDao {
 
-    public TkmsMariaDao(ITkmsDataSourceProvider dataSourceProvider, TkmsProperties properties, ITkmsMetricsTemplate metricsTemplate, ITkmsMessageSerializer messageSerializer, ITransactionsHelper transactionsHelper) {
-        super(dataSourceProvider, properties, metricsTemplate, messageSerializer, transactionsHelper);
+  public TkmsMariaDao(ITkmsDataSourceProvider dataSourceProvider, TkmsProperties properties, ITkmsMetricsTemplate metricsTemplate,
+    ITkmsMessageSerializer messageSerializer, ITransactionsHelper transactionsHelper) {
+    super(dataSourceProvider, properties, metricsTemplate, messageSerializer, transactionsHelper);
+  }
+
+  @Override
+  @Transactional(rollbackFor = Exception.class, isolation = Isolation.READ_UNCOMMITTED)
+  @MonitoringQuery
+  public long getApproximateMessagesCount(TkmsShardPartition sp) {
+    List<Long> rows =
+      jdbcTemplate.queryForList("select table_rows from information_schema.tables where table_schema=? and table_name = ?", Long.class,
+        getSchemaName(sp), getTableNameWithoutSchema(sp));
+
+    return rows.isEmpty() ? -1 : rows.get(0);
+  }
+
+  protected void validateEngineSpecificSchema() {
+    if (!properties.isTableStatsValidationEnabled()) {
+      return;
     }
 
-    @Override
-    @Transactional(rollbackFor = Exception.class, isolation = Isolation.READ_UNCOMMITTED)
-    @MonitoringQuery
-    public long getApproximateMessagesCount(TkmsShardPartition sp) {
-        List<Long> rows = jdbcTemplate.queryForList("select table_rows from information_schema.tables where table_schema=? and table_name = ?", Long.class, getSchemaName(sp), getTableNameWithoutSchema(sp));
+    try {
+      for (int s = 0; s < properties.getShardsCount(); s++) {
+        for (int p = 0; p < properties.getPartitionsCount(s); p++) {
+          TkmsShardPartition sp = TkmsShardPartition.of(s, p);
 
-        return rows.isEmpty() ? -1 : rows.get(0);
-    }
+          long rowsInTableStats = getRowsFromTableStats(sp);
+          long rowsInIndexStats = getRowsFromIndexStats(sp);
 
-    protected void validateEngineSpecificSchema() {
-        if (!properties.isTableStatsValidationEnabled()) {
-            return;
+          if (rowsInTableStats < 100000 || rowsInIndexStats < 100000) {
+            log.warn("Table for " + sp + " is not properly configured. Rows from table stats is " + rowsInTableStats + ", rows in index stats is "
+              + rowsInIndexStats + ". This can greatly affect performance during peaks or database slownesses.");
+          }
+
+          metricsTemplate.registerRowsInTableStats(sp, rowsInTableStats);
+          metricsTemplate.registerRowsInIndexStats(sp, rowsInIndexStats);
         }
+      }
+    } catch (Throwable t) {
+      log.error("Validating table and index stats failed. Will still continue with the initialization.", t);
+    }
+  }
 
-        try {
-            for (int s = 0; s < properties.getShardsCount(); s++) {
-                for (int p = 0; p < properties.getPartitionsCount(s); p++) {
-                    TkmsShardPartition sp = TkmsShardPartition.of(s, p);
+  private long getRowsFromTableStats(TkmsShardPartition shardPartition) {
+    List<Long> stats = jdbcTemplate.queryForList("select n_rows from mysql.innodb_table_stats where database_name=? and table_name=?", Long.class,
+      getSchemaName(shardPartition), getTableNameWithoutSchema(shardPartition));
 
-                    long rowsInTableStats = getRowsFromTableStats(sp);
-                    long rowsInIndexStats = getRowsFromIndexStats(sp);
+    if (stats.isEmpty()) {
+      return -1;
+    }
+    return stats.get(0);
+  }
 
-                    if (rowsInTableStats < 100000 || rowsInIndexStats < 100000) {
-                        log.warn("Table for " + sp + " is not properly configured. Rows from table stats is " + rowsInTableStats + ", rows in index stats is " + rowsInIndexStats + ". This can greatly affect performance during peaks or database slownesses.");
-                    }
+  private long getRowsFromIndexStats(TkmsShardPartition shardPartition) {
+    List<Long> stats = jdbcTemplate.queryForList(
+      "select stat_value from mysql.innodb_index_stats where database_name=? and stat_description='id' and " + "table_name=?", Long.class,
+      getSchemaName(shardPartition), getTableNameWithoutSchema(shardPartition));
 
-                    metricsTemplate.registerRowsInTableStats(sp, rowsInTableStats);
-                    metricsTemplate.registerRowsInIndexStats(sp, rowsInIndexStats);
-                }
-            }
-        } catch (Throwable t) {
-            log.error("Validating table and index stats failed. Will still continue with the initialization.", t);
-        }
+    if (stats.isEmpty()) {
+      return -1;
+    }
+    return stats.get(0);
+  }
+
+  protected boolean doesEarliestVisibleMessagesTableExist() {
+    String schema = currentSchema;
+    String table = properties.getEarliestVisibleMessages().getTableName();
+    if (StringUtils.contains(table, ".")) {
+      schema = StringUtils.substringBefore(table, ".");
+      table = StringUtils.substringAfter(table, ".");
     }
 
-    private long getRowsFromTableStats(TkmsShardPartition shardPartition) {
-        List<Long> stats = jdbcTemplate.queryForList("select n_rows from mysql.innodb_table_stats where database_name=? and table_name=?", Long.class, getSchemaName(shardPartition), getTableNameWithoutSchema(shardPartition));
+    return !jdbcTemplate.queryForList("SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", Boolean.class,
+      schema, table).isEmpty();
+  }
 
-        if (stats.isEmpty()) {
-            return -1;
-        }
-        return stats.get(0);
-    }
+  protected String getInsertSql(TkmsShardPartition shardPartition) {
+    return "insert into " + getTableName(shardPartition) + " (message) values (?)";
+  }
 
-    private long getRowsFromIndexStats(TkmsShardPartition shardPartition) {
-        List<Long> stats = jdbcTemplate.queryForList("select stat_value from mysql.innodb_index_stats where database_name=? and stat_description='id' and " + "table_name=?", Long.class, getSchemaName(shardPartition), getTableNameWithoutSchema(shardPartition));
+  protected String getSelectSql(TkmsShardPartition shardPartition) {
+    return "select id, message from " + getTableName(shardPartition) + " use index (PRIMARY) where id >= ? order by id limit ?";
+  }
 
-        if (stats.isEmpty()) {
-            return -1;
-        }
-        return stats.get(0);
-    }
-
-    protected boolean doesEarliestVisibleMessagesTableExist() {
-        String schema = currentSchema;
-        String table = properties.getEarliestVisibleMessages().getTableName();
-        if (StringUtils.contains(table, ".")) {
-            schema = StringUtils.substringBefore(table, ".");
-            table = StringUtils.substringAfter(table, ".");
-        }
-
-        return !jdbcTemplate.queryForList("SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", Boolean.class, schema, table).isEmpty();
-    }
-
-    protected String getInsertSql(TkmsShardPartition shardPartition) {
-        return "insert into " + getTableName(shardPartition) + " (message) values (?)";
-    }
-
-    protected String getSelectSql(TkmsShardPartition shardPartition) {
-        return "select id, message from " + getTableName(shardPartition) + " use index (PRIMARY) where id >= ? order by id limit ?";
-    }
-
-    protected String getCurrentSchema() {
-        return jdbcTemplate.queryForObject("select DATABASE()", String.class);
-    }
+  protected String getCurrentSchema() {
+    return jdbcTemplate.queryForObject("select DATABASE()", String.class);
+  }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
@@ -1,0 +1,98 @@
+package com.transferwise.kafka.tkms.dao;
+
+import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHelper;
+import com.transferwise.kafka.tkms.api.TkmsShardPartition;
+import com.transferwise.kafka.tkms.config.ITkmsDataSourceProvider;
+import com.transferwise.kafka.tkms.config.TkmsProperties;
+import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
+import com.transferwise.kafka.tkms.metrics.MonitoringQuery;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+public class TkmsMariaDao extends TkmsDao {
+
+    public TkmsMariaDao(ITkmsDataSourceProvider dataSourceProvider, TkmsProperties properties, ITkmsMetricsTemplate metricsTemplate, ITkmsMessageSerializer messageSerializer, ITransactionsHelper transactionsHelper) {
+        super(dataSourceProvider, properties, metricsTemplate, messageSerializer, transactionsHelper);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class, isolation = Isolation.READ_UNCOMMITTED)
+    @MonitoringQuery
+    public long getApproximateMessagesCount(TkmsShardPartition sp) {
+        List<Long> rows = jdbcTemplate.queryForList("select table_rows from information_schema.tables where table_schema=? and table_name = ?", Long.class, getSchemaName(sp), getTableNameWithoutSchema(sp));
+
+        return rows.isEmpty() ? -1 : rows.get(0);
+    }
+
+    protected void validateEngineSpecificSchema() {
+        if (!properties.isTableStatsValidationEnabled()) {
+            return;
+        }
+
+        try {
+            for (int s = 0; s < properties.getShardsCount(); s++) {
+                for (int p = 0; p < properties.getPartitionsCount(s); p++) {
+                    TkmsShardPartition sp = TkmsShardPartition.of(s, p);
+
+                    long rowsInTableStats = getRowsFromTableStats(sp);
+                    long rowsInIndexStats = getRowsFromIndexStats(sp);
+
+                    if (rowsInTableStats < 100000 || rowsInIndexStats < 100000) {
+                        log.warn("Table for " + sp + " is not properly configured. Rows from table stats is " + rowsInTableStats + ", rows in index stats is " + rowsInIndexStats + ". This can greatly affect performance during peaks or database slownesses.");
+                    }
+
+                    metricsTemplate.registerRowsInTableStats(sp, rowsInTableStats);
+                    metricsTemplate.registerRowsInIndexStats(sp, rowsInIndexStats);
+                }
+            }
+        } catch (Throwable t) {
+            log.error("Validating table and index stats failed. Will still continue with the initialization.", t);
+        }
+    }
+
+    private long getRowsFromTableStats(TkmsShardPartition shardPartition) {
+        List<Long> stats = jdbcTemplate.queryForList("select n_rows from mysql.innodb_table_stats where database_name=? and table_name=?", Long.class, getSchemaName(shardPartition), getTableNameWithoutSchema(shardPartition));
+
+        if (stats.isEmpty()) {
+            return -1;
+        }
+        return stats.get(0);
+    }
+
+    private long getRowsFromIndexStats(TkmsShardPartition shardPartition) {
+        List<Long> stats = jdbcTemplate.queryForList("select stat_value from mysql.innodb_index_stats where database_name=? and stat_description='id' and " + "table_name=?", Long.class, getSchemaName(shardPartition), getTableNameWithoutSchema(shardPartition));
+
+        if (stats.isEmpty()) {
+            return -1;
+        }
+        return stats.get(0);
+    }
+
+    protected boolean doesEarliestVisibleMessagesTableExist() {
+        String schema = currentSchema;
+        String table = properties.getEarliestVisibleMessages().getTableName();
+        if (StringUtils.contains(table, ".")) {
+            schema = StringUtils.substringBefore(table, ".");
+            table = StringUtils.substringAfter(table, ".");
+        }
+
+        return !jdbcTemplate.queryForList("SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", Boolean.class, schema, table).isEmpty();
+    }
+
+    protected String getInsertSql(TkmsShardPartition shardPartition) {
+        return "insert into " + getTableName(shardPartition) + " (message) values (?)";
+    }
+
+    protected String getSelectSql(TkmsShardPartition shardPartition) {
+        return "select id, message from " + getTableName(shardPartition) + " use index (PRIMARY) where id >= ? order by id limit ?";
+    }
+
+    protected String getCurrentSchema() {
+        return jdbcTemplate.queryForObject("select DATABASE()", String.class);
+    }
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
@@ -6,18 +6,22 @@ import com.transferwise.kafka.tkms.config.ITkmsDataSourceProvider;
 import com.transferwise.kafka.tkms.config.TkmsProperties;
 import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
 import com.transferwise.kafka.tkms.metrics.MonitoringQuery;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Slf4j
 public class TkmsMariaDao extends TkmsDao {
 
-  public TkmsMariaDao(ITkmsDataSourceProvider dataSourceProvider, TkmsProperties properties, ITkmsMetricsTemplate metricsTemplate,
-    ITkmsMessageSerializer messageSerializer, ITransactionsHelper transactionsHelper) {
+  public TkmsMariaDao(
+      ITkmsDataSourceProvider dataSourceProvider,
+      TkmsProperties properties,
+      ITkmsMetricsTemplate metricsTemplate,
+      ITkmsMessageSerializer messageSerializer,
+      ITransactionsHelper transactionsHelper
+  ) {
     super(dataSourceProvider, properties, metricsTemplate, messageSerializer, transactionsHelper);
   }
 
@@ -26,7 +30,7 @@ public class TkmsMariaDao extends TkmsDao {
   @MonitoringQuery
   public long getApproximateMessagesCount(TkmsShardPartition sp) {
     List<Long> rows =
-      jdbcTemplate.queryForList("select table_rows from information_schema.tables where table_schema=? and table_name = ?", Long.class,
+        jdbcTemplate.queryForList("select table_rows from information_schema.tables where table_schema=? and table_name = ?", Long.class,
         getSchemaName(sp), getTableNameWithoutSchema(sp));
 
     return rows.isEmpty() ? -1 : rows.get(0);
@@ -47,7 +51,7 @@ public class TkmsMariaDao extends TkmsDao {
 
           if (rowsInTableStats < 100000 || rowsInIndexStats < 100000) {
             log.warn("Table for " + sp + " is not properly configured. Rows from table stats is " + rowsInTableStats + ", rows in index stats is "
-              + rowsInIndexStats + ". This can greatly affect performance during peaks or database slownesses.");
+                + rowsInIndexStats + ". This can greatly affect performance during peaks or database slownesses.");
           }
 
           metricsTemplate.registerRowsInTableStats(sp, rowsInTableStats);
@@ -61,7 +65,7 @@ public class TkmsMariaDao extends TkmsDao {
 
   private long getRowsFromTableStats(TkmsShardPartition shardPartition) {
     List<Long> stats = jdbcTemplate.queryForList("select n_rows from mysql.innodb_table_stats where database_name=? and table_name=?", Long.class,
-      getSchemaName(shardPartition), getTableNameWithoutSchema(shardPartition));
+        getSchemaName(shardPartition), getTableNameWithoutSchema(shardPartition));
 
     if (stats.isEmpty()) {
       return -1;
@@ -71,8 +75,8 @@ public class TkmsMariaDao extends TkmsDao {
 
   private long getRowsFromIndexStats(TkmsShardPartition shardPartition) {
     List<Long> stats = jdbcTemplate.queryForList(
-      "select stat_value from mysql.innodb_index_stats where database_name=? and stat_description='id' and " + "table_name=?", Long.class,
-      getSchemaName(shardPartition), getTableNameWithoutSchema(shardPartition));
+        "select stat_value from mysql.innodb_index_stats where database_name=? and stat_description='id' and " + "table_name=?", Long.class,
+        getSchemaName(shardPartition), getTableNameWithoutSchema(shardPartition));
 
     if (stats.isEmpty()) {
       return -1;

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
@@ -3,13 +3,12 @@ package com.transferwise.kafka.tkms.dao;
 import com.google.common.primitives.Longs;
 import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHelper;
 import com.transferwise.kafka.tkms.api.TkmsShardPartition;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.transferwise.kafka.tkms.config.ITkmsDataSourceProvider;
 import com.transferwise.kafka.tkms.config.TkmsProperties;
 import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.transaction.annotation.Isolation;
@@ -18,9 +17,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class TkmsPostgresDao extends TkmsDao {
 
-  public TkmsPostgresDao(ITkmsDataSourceProvider dataSourceProvider, TkmsProperties properties,
-                         ITkmsMetricsTemplate metricsTemplate, ITkmsMessageSerializer messageSerializer,
-                         ITransactionsHelper transactionsHelper
+  public TkmsPostgresDao(
+      ITkmsDataSourceProvider dataSourceProvider,
+      TkmsProperties properties,
+      ITkmsMetricsTemplate metricsTemplate,
+      ITkmsMessageSerializer messageSerializer,
+      ITransactionsHelper transactionsHelper
   ) {
     super(dataSourceProvider, properties, metricsTemplate, messageSerializer, transactionsHelper);
   }
@@ -47,7 +49,7 @@ public class TkmsPostgresDao extends TkmsDao {
     }
 
     return !jdbcTemplate.queryForList("SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", String.class,
-        schema, table).isEmpty();
+      schema, table).isEmpty();
   }
 
   @Override
@@ -67,7 +69,6 @@ public class TkmsPostgresDao extends TkmsDao {
           TkmsShardPartition sp = TkmsShardPartition.of(s, p);
 
           long distinctIdsCount = getDistinctIdsCount(sp);
-
           if (distinctIdsCount < 100000) {
             log.warn("Table for " + sp + " is not properly configured. Rows from table stats is " + distinctIdsCount
                 + ". This can greatly affect performance during peaks or database slownesses.");
@@ -86,17 +87,17 @@ public class TkmsPostgresDao extends TkmsDao {
   public long getApproximateMessagesCount(TkmsShardPartition sp) {
     List<Long> rows =
         jdbcTemplate.queryForList("SELECT reltuples as approximate_row_count FROM pg_class, pg_namespace WHERE "
-                + " pg_class.relnamespace=pg_namespace.oid and nspname=? and relname = ?", Long.class,
-            getSchemaName(sp), getTableNameWithoutSchema(sp));
+            + " pg_class.relnamespace=pg_namespace.oid and nspname=? and relname = ?", Long.class,
+        getSchemaName(sp), getTableNameWithoutSchema(sp));
 
     return rows.isEmpty() ? -1 : rows.get(0);
   }
 
   protected long getDistinctIdsCount(TkmsShardPartition sp) {
     List<String> relOptionsList =
-        jdbcTemplate.queryForList("select attoptions from pg_attribute, pg_class, pg_namespace where pg_class.oid = pg_attribute.attrelid "
-            + "and pg_class.relnamespace = pg_namespace.oid "
-            + "and pg_namespace.nspname=? and pg_class.relname=? and attname='id'", String.class, getSchemaName(sp), getTableNameWithoutSchema(sp));
+          jdbcTemplate.queryForList("select attoptions from pg_attribute, pg_class, pg_namespace where pg_class.oid = pg_attribute.attrelid "
+          + "and pg_class.relnamespace = pg_namespace.oid "
+          + "and pg_namespace.nspname=? and pg_class.relname=? and attname='id'", String.class, getSchemaName(sp), getTableNameWithoutSchema(sp));
 
     if (relOptionsList.isEmpty()) {
       return -1;

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
@@ -1,10 +1,15 @@
 package com.transferwise.kafka.tkms.dao;
 
 import com.google.common.primitives.Longs;
+import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHelper;
 import com.transferwise.kafka.tkms.api.TkmsShardPartition;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import com.transferwise.kafka.tkms.config.ITkmsDataSourceProvider;
+import com.transferwise.kafka.tkms.config.TkmsProperties;
+import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.transaction.annotation.Isolation;
@@ -12,6 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 public class TkmsPostgresDao extends TkmsDao {
+
+  public TkmsPostgresDao(ITkmsDataSourceProvider dataSourceProvider, TkmsProperties properties,
+                         ITkmsMetricsTemplate metricsTemplate, ITkmsMessageSerializer messageSerializer,
+                         ITransactionsHelper transactionsHelper
+  ) {
+    super(dataSourceProvider, properties, metricsTemplate, messageSerializer, transactionsHelper);
+  }
 
   public static final Pattern N_DISTINCT_PATTERN = Pattern.compile("n_distinct=(.*)[,}]");
 


### PR DESCRIPTION
## Context

In this PR making TkmsDao abstract and provide explicit implementation for MariaDb. Try to limit DI to ctor rather than field injection at touched code. Also allowing override of database dialect per shard. As first step to allow tkms to use multiple datasources in more complex scenarios.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
