### PR TITLE
PC-655 bump protobuf-java because of CVE-2022-3171

### DIFF
--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,5 +1,5 @@
 ext {
-    protobufVersion = "3.20.3"
+    protobufVersion = "3.21.9"
     libraries = [
             // version defined
             awaitility                      : 'org.awaitility:awaitility:4.1.1',

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,5 +1,5 @@
 ext {
-    protobufVersion = "3.20.1"
+    protobufVersion = "3.20.3"
     libraries = [
             // version defined
             awaitility                      : 'org.awaitility:awaitility:4.1.1',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.16.0
+version=0.16.1


### PR DESCRIPTION
## Context

https://transferwise.atlassian.net/browse/PC-655

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
