### PR TITLE
Support override of table name per shard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2022-12-02
+### Changed
+* Allow override of table base name per shard.
+
 ## [0.18.0] - 2022-11-28
 ### Changed
 * Make TkmsDao abstract and provide two implementations TkmsMariaDao and TkmsPostgresDao.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.18.0
+version=0.19.0

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -174,6 +174,7 @@ public class TkmsProperties {
   @Accessors(chain = true)
   public static class ShardProperties {
 
+    private String tableBaseName;
     private DatabaseDialect databaseDialect;
     private Integer partitionsCount;
     private Integer pollerBatchSize;
@@ -185,6 +186,14 @@ public class TkmsProperties {
     private EarliestVisibleMessages earliestVisibleMessages;
 
     private Map<String, String> kafka = new HashMap<>();
+  }
+
+  public String getTableBaseName(int shard) {
+    ShardProperties shardProperties = shards.get(shard);
+    if (shardProperties != null && shardProperties.getTableBaseName() != null) {
+      return shardProperties.getTableBaseName();
+    }
+    return tableBaseName;
   }
 
   public DatabaseDialect getDatabaseDialect(int shard) {

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
@@ -371,7 +371,7 @@ public abstract class TkmsDao implements ITkmsDao {
    * <p>A Method calling this method should cache the result itself.
    */
   protected String getTableName(TkmsShardPartition shardPartition) {
-    return properties.getTableBaseName() + "_" + shardPartition.getShard() + "_" + shardPartition.getPartition();
+    return properties.getTableBaseName(shardPartition.getShard()) + "_" + shardPartition.getShard() + "_" + shardPartition.getPartition();
   }
 
   protected String getTableNameWithoutSchema(TkmsShardPartition shardPartition) {

--- a/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/TkmsTestDao.java
+++ b/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/TkmsTestDao.java
@@ -33,6 +33,6 @@ public class TkmsTestDao implements ITkmsTestDao {
 
 
   protected String getTableName(TkmsShardPartition shardPartition) {
-    return properties.getTableBaseName() + "_" + shardPartition.getShard() + "_" + shardPartition.getPartition();
+    return properties.getTableBaseName(shardPartition.getShard()) + "_" + shardPartition.getShard() + "_" + shardPartition.getPartition();
   }
 }


### PR DESCRIPTION
## Context

Allow support for having different `tableBaseName` per shard. This can help in cases where you have more than one datasource and one of them might already have a default `outgoing_message_XX_YY` table.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
