### PR TITLE
Make init() method public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.1] - 2022-12-05
+### Changed
+* @PostConstruct init() method is now `public`.
+
 ## [0.19.0] - 2022-12-02
 ### Changed
 * Allow override of table base name per shard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.1] - 2022-12-05
 ### Changed
-* @PostConstruct init() method is now `public`.
+* `@PostConstruct init()` method is now `public`.
 
 ## [0.19.0] - 2022-12-02
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.19.0
+version=0.19.1

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
@@ -72,7 +72,7 @@ public abstract class TkmsDao implements ITkmsDao {
   protected String currentSchema;
 
   @PostConstruct
-  protected void init() {
+  public void init() {
     jdbcTemplate = new JdbcTemplate(dataSourceProvider.getDataSource());
 
     transactionsHelper.withTransaction().withIsolation(Isolation.READ_UNCOMMITTED).run(() -> currentSchema = getCurrentSchema());


### PR DESCRIPTION
## Context

Make `@PostConstruct init()` method public. We need this to be able to manually instantiate correctly concrete classes of TkmsDao such as for MariaDb & PostgreSQL. 

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
