### PR TITLE
fix: bump proto CVE-2022-3509

### DIFF
--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,5 +1,5 @@
 ext {
-    protobufVersion = "3.21.9"
+    protobufVersion = "3.21.10"
     springBootVersion = "${System.getenv("SPRING_BOOT_VERSION") ?: '2.6.14'}"
     libraries = [
             // version defined


### PR DESCRIPTION
## Context

Bump protobuf version to fix CVE-2022-3509

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
