### PR TITLE
Bump all MariaDB 10.4s to 10.6 due to DB deprecation risk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       image: azul/zulu-openjdk:11
     services:
       mysql1:
-        image: mariadb:10.4
+        image: mariadb:10.6
         env:
           MYSQL_ROOT_PASSWORD: example-password-change-me
           MYSQL_DATABASE: tkms
@@ -115,7 +115,7 @@ jobs:
           name: all-test-reports-${{ matrix.spring_boot_version }}
           path: all-test-reports-${{ matrix.spring_boot_version }}.tar.gz
           retention-days: 7
-        
+
   build:
     name: "Build and Test"
     runs-on:

--- a/demoapp/docker/docker-compose.yml
+++ b/demoapp/docker/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       KAFKA_JVM_PERFORMANCE_OPTS: -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -noverify -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
 #      KAFKA_CREATE_TOPICS: "MyTopic:10:1"
   mariadb:
-    image: mariadb:10.4
+    image: mariadb:10.6
     hostname: mysql
     ports:
       - "13306:3306"


### PR DESCRIPTION
## Context

All MariaDB 10.4 containers have to be bumped to 10.6 to eliminate database deprecation risk.

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
