### PR TITLE
Fixing master build around creating a new release tag.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
         if: ${{ needs.matrix_build.result != 'success' }}
         run: exit 1
       - name: "Install packages"
-        run: apt-get update && apt-get install -y unzip
+        run: apt-get update && apt-get install -y git unzip
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup Gradle


### PR DESCRIPTION
## Context

Fixing master build around creating a new release tag.

Currently master build fails with:
```
Caused by: java.lang.NullPointerException: Cannot get property 'tag' on null object
    at build_4ink9v62nmhzv885ajhcxydwc$_run_closure3$_closure5.doCall(/__w/tw-tkms/tw-tkms/build.gradle:34)
```

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
