### PR TITLE
Improved the performance and its stability of databases under Tkms.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: example-password-change-me
           MYSQL_DATABASE: tkms
       postgres1:
-        image: postgres:12
-        env:
-          POSTGRES_PASSWORD: example-password-change-me
+        image: docker.tw.ee/postgres12
       zk-service1:
         image: bitnami/zookeeper:3.5.5
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
           MYSQL_DATABASE: tkms
       postgres1:
         image: postgres:12
+        env:
+          POSTGRES_PASSWORD: example-password-change-me
       zk-service1:
         image: bitnami/zookeeper:3.5.5
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: example-password-change-me
           MYSQL_DATABASE: tkms
       postgres1:
-        image: postgres:12
+        image: transferwiseworkspace/postgres12
         env:
           POSTGRES_PASSWORD: example-password-change-me
       zk-service1:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: example-password-change-me
           MYSQL_DATABASE: tkms
       postgres1:
-        image: docker.tw.ee/postgres12
+        image: postgres:12
       zk-service1:
         image: bitnami/zookeeper:3.5.5
         env:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # TransferWise Transactional Kafka Message Sender
+
 ![Apache 2](https://img.shields.io/hexpm/l/plug.svg)
 ![Java 11](https://img.shields.io/badge/Java-11-blue.svg)
 ![Maven Central](https://badgen.net/maven/v/maven-central/com.transferwise.kafka/tw-tkms-starter)
@@ -9,9 +10,10 @@
 A library for sending Kafka messages according to the [Transactional Outbox Pattern](https://microservices.io/patterns/data/transactional-outbox.html)
 
 * Guarantees messages ordering
-  * Messages with the same key/partition added in a transaction, will end up in a target Kafka partition in the order they were added.
-  * Messages with the same key/partition added in two consecutive transactions will end up in the correct Kafka partition in the order they were added.
-  * There are no illusionary global ordering guarantees, the same as for Kafka itself.
+    * Messages with the same key/partition added in a transaction, will end up in a target Kafka partition in the order they were added.
+    * Messages with the same key/partition added in two consecutive transactions will end up in the correct Kafka partition in the order they were
+      added.
+    * There are no illusionary global ordering guarantees, the same as for Kafka itself.
 * Efficient and high performance
 * Supports both JSON and binary messages
 * Supports all Kafka Client features, like headers and forcing messages into specific partitions
@@ -20,10 +22,11 @@ A library for sending Kafka messages according to the [Transactional Outbox Patt
 * Supports both Postgres and MariaDb.
 
 Do not use this library
+
 * If you do not need atomic transactions around your business data and Kafka messages.
-  * For example:
-    * You are just converting incoming Kafka messages into messages for another topic.
-    * The only thing your logic does is send out Kafka messages and it does not change the main database.
+    * For example:
+        * You are just converting incoming Kafka messages into messages for another topic.
+        * The only thing your logic does is send out Kafka messages and it does not change the main database.
 
 You would probably want to start by going over the [main concepts](docs/concepts.md).
 
@@ -39,12 +42,16 @@ If there's any [trouble](docs/troubleshooting.md), you will be prepared.
 
 The library also provides [observability](docs/observability.md).
 
-At TransferWise we are "enhancing and fixing a flying airplane", so make sure you will not cause any incidents while
+At Wise we are "enhancing and fixing a flying airplane", so make sure you will not cause any incidents while
 [migrating](docs/migration.md) to the library.
 
 Feel free to [contribute](docs/contributing.md) and come and chat in the #tw-task-exec Slack channel.
 
+If you are a Postgres database user, then it is utmost important to be familiar
+with [Postgres OLAP/HTAP workloads issues](docs/postgres_with_long_transactions.md)
+
 ## License
+
 Copyright 2021 TransferWise Ltd.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -20,8 +20,8 @@ ext {
             twContextStarter                : 'com.transferwise.common:tw-context-starter:0.11.1',
             twGracefulShutdown              : 'com.transferwise.common:tw-graceful-shutdown:2.8.0',
             twGracefulShutdownInterfaces    : 'com.transferwise.common:tw-graceful-shutdown-interfaces:2.8.0',
-            twLeaderSelector                : 'com.transferwise.common:tw-leader-selector:1.8.0',
-            twLeaderSelectorStarter         : 'com.transferwise.common:tw-leader-selector-starter:1.8.0',
+            twLeaderSelector                : 'com.transferwise.common:tw-leader-selector:1.9.0',
+            twLeaderSelectorStarter         : 'com.transferwise.common:tw-leader-selector-starter:1.9.0',
             zstdJni                         : 'com.github.luben:zstd-jni:1.5.0-4',
 
             // versions managed by spring-boot-dependencies platform

--- a/demoapp/docker/docker-compose.yml
+++ b/demoapp/docker/docker-compose.yml
@@ -65,10 +65,6 @@ services:
   #    --innodb_flush_log_at_trx_commit=1 --innodb_flush_method=O_DIRECT_NO_FSYNC
 
   postgres:
-    image: postgres:12-alpine
+    image: docker.tw.ee/postgres12
     ports:
       - "15432:5432"
-    environment:
-      POSTGRES_PASSWORD: example-password-change-me
-    command: -c 'max_connections=200'
-

--- a/demoapp/src/main/java/com/transferwise/kafka/tkms/demoapp/KafkaConfiguration.java
+++ b/demoapp/src/main/java/com/transferwise/kafka/tkms/demoapp/KafkaConfiguration.java
@@ -21,8 +21,6 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.KafkaAdmin;
-import org.springframework.kafka.listener.CommonErrorHandler;
-import org.springframework.kafka.listener.CommonLoggingErrorHandler;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -70,7 +68,8 @@ public class KafkaConfiguration {
     ConcurrentKafkaListenerContainerFactory<String, byte[]> factory = new ConcurrentKafkaListenerContainerFactory<>();
     factory.setConsumerFactory(consumerFactory());
     factory.setBatchListener(true);
-    factory.setCommonErrorHandler(new CommonLoggingErrorHandler());
+    // Deprecated, but needed to support Spring Boot 2.5 as well.
+    factory.setBatchErrorHandler((e, data) -> log.error(e.getMessage(), e));
     return factory;
   }
 

--- a/demoapp/src/main/java/com/transferwise/kafka/tkms/demoapp/KafkaConfiguration.java
+++ b/demoapp/src/main/java/com/transferwise/kafka/tkms/demoapp/KafkaConfiguration.java
@@ -21,6 +21,8 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.CommonLoggingErrorHandler;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -68,7 +70,7 @@ public class KafkaConfiguration {
     ConcurrentKafkaListenerContainerFactory<String, byte[]> factory = new ConcurrentKafkaListenerContainerFactory<>();
     factory.setConsumerFactory(consumerFactory());
     factory.setBatchListener(true);
-    factory.setBatchErrorHandler((e, data) -> log.error(e.getMessage(), e));
+    factory.setCommonErrorHandler(new CommonLoggingErrorHandler());
     return factory;
   }
 

--- a/demoapp/src/main/java/db/migration/postgres/V1__Init.java
+++ b/demoapp/src/main/java/db/migration/postgres/V1__Init.java
@@ -17,10 +17,11 @@ public class V1__Init extends BaseJavaMigration {
           stmt.execute("CREATE TABLE " + tableName + " (\n"
               + "  id BIGSERIAL PRIMARY KEY,\n"
               + "  message BYTEA NOT NULL\n"
-              + ") WITH (autovacuum_analyze_threshold=1000000000)");
+              + ") WITH (autovacuum_analyze_threshold=1000000000, toast_tuple_target=8160)");
           log.info("Create table `" + tableName + "'.");
 
           stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN id SET (n_distinct=1000000);");
+          stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN message SET STORAGE EXTERNAL");
           stmt.executeUpdate("VACUUM FULL " + tableName);
         }
       }

--- a/demoapp/src/main/java/db/migration/postgres/V1__Init.java
+++ b/demoapp/src/main/java/db/migration/postgres/V1__Init.java
@@ -17,7 +17,7 @@ public class V1__Init extends BaseJavaMigration {
           stmt.execute("CREATE TABLE " + tableName + " (\n"
               + "  id BIGSERIAL PRIMARY KEY,\n"
               + "  message BYTEA NOT NULL\n"
-              + ") WITH (autovacuum_analyze_threshold=1000000000, autovacuum_vacuum_threshold=100000)");
+              + ") WITH (autovacuum_analyze_threshold=1000000000)");
           log.info("Create table `" + tableName + "'.");
 
           stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN id SET (n_distinct=1000000);");

--- a/docs/database_statistics_bias.md
+++ b/docs/database_statistics_bias.md
@@ -14,36 +14,43 @@ Databases gather/calculate table and index statistics for the query planner to u
 > Describing the mechanisms and triggers for statistics gathering, is out of the scope of this documentation. And, it is not necessary to know them.
 
 Most of the time, `Tkms` tables are empty. So there is a very high chance that database statistics collector will register table and index statistics
-at those points, registering that table is empty or at least almost empty.
+at those times, registering that table is empty or at least almost empty.
 
-When a database executes queries, it has to generate a plan for those. However, it uses the "old" statistics, which could easily have been taken hours
-ago.
+When a database executes queries, it has to generate a query plan for those. For that, it uses the previously collected statistics.
+Those statistic can easily be hours old. There is no magical mechanism for query planner is able to use some kind of "real time" data for itself.
 
 Now, let's assume that there is a spike of messages, where a substantial amount of records will be written into `Tkms` tables. Let's say we
 accumulate 100k messages.
 
-Now, let's look a simple query `Tkms` proxy component does: `DELETE from outgoing_message_0_0 where id in (1,2,3,4,5,6,7,8,9)`.
+Now, let's look a simple query `Tkms`'s `to-kafka-proxy` component does: `DELETE from outgoing_message_0_0 where id in (1,2,3,4,5,6,7,8,9)`.
 
-Now of course, any sane person would use PRIMARY key index here, but the database does not "know" the table has 100k records, its statistics are
-telling it that the table is empty. If a table is empty or close to empty, the most efficient would be do it via sequential scan (aka full table scan)
-and that is what database does, sequential scan over 100k records.
+Now of course, any sane person would use PRIMARY key index based query plan here, but the database does not "know" the table has 100k records.
+Its statistics are telling it that the table is empty.
+And in general, if a table is empty or close to empty, the most efficient query plan would be to execute sequential scan (aka full table scan)
+and that is what database does - a sequential scan over 100k records.
 
 This of course can run very slowly. Worse, those queries will slow down the `Tkms` proxy cycle and the pace of sending messages to Kafka can
-get behind the pace of registering new messages. Meaning, that table will continue growing, proxy cycle will get slower and slower and there
-at one point those queries are monopolizing all database resources making everything for a service slow, not just `Tkms`.
+get behind the pace of registering new messages. Meaning, that the table will continue growing, proxy cycle will get slower and slower and there
+at one point those queries are monopolizing all database resources making everything for a service slow, not just `Tkms`. 
+And the database could run into such a resource starvation that even the statistics collector would not be able to execute anymore.
 
 And when you reach that situation, there is not much hope, that the database will recover from that situation by itself.
 
 ## Remedies
 
-There are two main remedies for this from `Tkms` side: index hints and fixing statistics in place.
+There are two main remedies for this in `Tkms` implementation:
+* utilizing index hints
+* fixing statistics into a place.
 
 ### Index hints
 
-First, it tries to use force correct plans by applying index hints to all queries.
+First, it tries to force correct query plans by applying index hints to all queries.
 Index hints are built into MariaDb and MySql; and for Postgres there is the [pg_hint_plan](https://github.com/ossc-db/pg_hint_plan) extension.
 
 Unfortunately MariaDb does not support index hints on `DELETE` queries. MySql does.
+
+> So for MariaDb we still have a big risk.
+> Even when we fix the statistic in place, a DBA accidentally running manual `ANALYZE` will override and thus negate those fixed statistics.
 
 ### Fixing statistics in place.
 
@@ -61,19 +68,24 @@ flush table outgoing_message_*_*;
 ```
 <!-- @formatter:on -->
 
-## Manual intervention 
+## Manual intervention
 
-When `Tkms` tables have accumulated lots of records and sequential scans get executed, running `ANALYZE` on `tw-tkms` tables
-will allow to overcome and recover the situation.
+When `Tkms` tables have accumulated lots of records and sequential scans get executed and we already have an incident, 
+then running `ANALYZE` on `tw-tkms` tables will allow to overcome and recover the situation.
 
 ## Configuration change
 
 The only query not covered by an index hint, is `DELETE` query for MariaDb.
 
+If accidental `ANALYZE` would override our custom in place index statistics, the bad queries can still happen.
+
 In this case, the `delete-batch-sizes` property would allow to configure the queries to use less parameters per batch and thus having higher chance
 of avoiding sequential scans.
 
-E.g. 
+> But it would be about reducing the probability and not eliminating the risk completely.
+
+You can apply the custom configuration for deletion batch sizes as following. 
+
 ```yaml
 tw-tkms:
   delete-batch-sizes: "50, 10, 2, 1"

--- a/docs/database_statistics_bias.md
+++ b/docs/database_statistics_bias.md
@@ -1,0 +1,80 @@
+# Database statistics bias
+
+`Tkms` is using tables, into which messages are inserted, then polled and afterwards deleted.
+
+I.e. it has a rapid INSERT/DELETE type of workload.
+
+This is a workload type, which all database are advising against using, where one reason among many is that quite awful query plans can easily be
+derived.
+
+Let's see how this usually happens.
+
+Databases gather/calculate table and index statistics for the query planner to use, not in real time, but from time to time.
+
+> Describing the mechanisms and triggers for statistics gathering, is out of the scope of this documentation. And, it is not necessary to know them.
+
+Most of the time, `Tkms` tables are empty. So there is a very high chance that database statistics collector will register table and index statistics
+at those points, registering that table is empty or at least almost empty.
+
+When a database executes queries, it has to generate a plan for those. However, it uses the "old" statistics, which could easily have been taken hours
+ago.
+
+Now, let's assume that there is a spike of messages, where a substantial amount of records will be written into `Tkms` tables. Let's say we
+accumulate 100k messages.
+
+Now, let's look a simple query `Tkms` proxy component does: `DELETE from outgoing_message_0_0 where id in (1,2,3,4,5,6,7,8,9)`.
+
+Now of course, any sane person would use PRIMARY key index here, but the database does not "know" the table has 100k records, its statistics are
+telling it that the table is empty. If a table is empty or close to empty, the most efficient would be do it via sequential scan (aka full table scan)
+and that is what database does, sequential scan over 100k records.
+
+This of course can run very slowly. Worse, those queries will slow down the `Tkms` proxy cycle and the pace of sending messages to Kafka can
+get behind the pace of registering new messages. Meaning, that table will continue growing, proxy cycle will get slower and slower and there
+at one point those queries are monopolizing all database resources making everything for a service slow, not just `Tkms`.
+
+And when you reach that situation, there is not much hope, that the database will recover from that situation by itself.
+
+## Remedies
+
+There are two main remedies for this from `Tkms` side: index hints and fixing statistics in place.
+
+### Index hints
+
+First, it tries to use force correct plans by applying index hints to all queries.
+Index hints are built into MariaDb and MySql; and for Postgres there is the [pg_hint_plan](https://github.com/ossc-db/pg_hint_plan) extension.
+
+Unfortunately MariaDb does not support index hints on `DELETE` queries. MySql does.
+
+### Fixing statistics in place.
+
+[setup guide](setup.md) will show you how.
+
+In the case of MariaDb/MySql, it is very important to avoid running ANALYZE on those tables, because those will overwrite all our fixed statistics.
+
+If this happens, it is important to fix the statistics back into place.
+
+<!-- @formatter:off -->
+```mariadb
+update mysql.innodb_index_stats set stat_value=1000000 where table_name like "outgoing_message_%" and stat_description="id";
+update mysql.innodb_table_stats set n_rows=1000000 where table_name like "outgoing_message_%";
+flush table outgoing_message_*_*;
+```
+<!-- @formatter:on -->
+
+## Manual intervention 
+
+When `Tkms` tables have accumulated lots of records and sequential scans get executed, running `ANALYZE` on `tw-tkms` tables
+will allow to overcome and recover the situation.
+
+## Configuration change
+
+The only query not covered by an index hint, is `DELETE` query for MariaDb.
+
+In this case, the `delete-batch-sizes` property would allow to configure the queries to use less parameters per batch and thus having higher chance
+of avoiding sequential scans.
+
+E.g. 
+```yaml
+tw-tkms:
+  delete-batch-sizes: "50, 10, 2, 1"
+```

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -36,7 +36,7 @@ tune according to your monitoring results.
 > a similar systems in place and may need a simple rate limiter around the sender.
 
 To increase the throughput, you can configure more partitions (and create additional tables), but this is usually not needed in a typical
-TransferWise service. 
+Wise service. 
 
 Consider batching of messages. The most beneficial is to make sure, that there is a single transaction around multiple messages sending.
 As the library is used for Transactional Outbox Pattern, we can assume, this is mostly the case.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,24 +1,26 @@
-# Setup 
+# Setup
+
 We are assuming you are using Spring Boot, at least version 2.1.
 
 As usual, we can incorporate it into your Service through [tw-dependency](https://github.com/transferwise/tw-dependencies)
+
 ```groovy
-implementation platform("com.transferwise.common:tw-dependencies:${twDependenciesVersion}")
 implementation 'com.transferwise.kafka:tw-tkms-starter'
 ```
 
 Configuration can be tweaked according to `com.transferwise.kafka.tkms.config.TkmsProperties`. Usually there is no need to change the defaults.
 
-Minumum required configuration is:
+Minimum required configuration is:
+
 ```
 tw-tkms:
-  database-dialect: POSTGRES # only required if using Postgres, Mysql is default
+  database-dialect: POSTGRES # only required if using Postgres, MariaDb is the default
   kafka.bootstrap.servers: ${ENV_SECURE_KAFKA_BOOTSTRAP_SERVERS}
   environment:
     previous-version: ${LIB_VERSION} # use current lib version for a new integration
 ```
 
-Of course you need to create tables in the database as well.
+Of course, you need to create tables in the database as well.
 
 For each shard & partition combination, you need a table in a form of `outgoing_message_<shard>_<partition>`.
 
@@ -30,6 +32,7 @@ optimal performance even in cases where those tables will suddenly accumulate la
 
 ## MariaDb
 
+<!-- @formatter:off -->
 ```mariadb
 CREATE TABLE outgoing_message_0_0 (
               id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -40,32 +43,44 @@ update mysql.innodb_index_stats set stat_value=1000000 where table_name = "outgo
 update mysql.innodb_table_stats set n_rows=1000000 where table_name like "outgoing_message_0_0";
 flush table outgoing_message_0_0;
 ```
+<!-- @formatter:on -->
+
+> Make sure you never run ANALYZE on those tables as it will overwrite those stats, and you will end up with database going crazy on certain
+> situations.
 
 As some of those commands require specific permissions, you most likely will need some help from DBAs.
 
-Also, it is beneficial (but not crucial) to set [innodb_autoinc_lock_mode](https://mariadb.com/docs/reference/es/system-variables/innodb_autoinc_lock_mode/) to 2.
+Also, it is beneficial (but not crucial) to
+set [innodb_autoinc_lock_mode](https://mariadb.com/docs/reference/es/system-variables/innodb_autoinc_lock_mode/) to 2.
 
 ## Postgres
 
+It is utmost important to have [pg_hint_plan](https://github.com/ossc-db/pg_hint_plan) extension installed in Postgres.
+
+<!-- @formatter:off -->
 ```postgresql
 CREATE TABLE outgoing_message_0_0 (
   id BIGSERIAL PRIMARY KEY,
   message BYTEA NOT NULL
-) WITH (autovacuum_analyze_threshold=2000000000, autovacuum_vacuum_threshold=100000, toast_tuple_target=8160);
+) WITH (autovacuum_analyze_threshold=2000000000, toast_tuple_target=8160);
 
 ALTER TABLE outgoing_message_0_0 ALTER COLUMN id SET (n_distinct=1000000);
 VACUUM FULL outgoing_message_0_0;
 ```
->> toast_tuple_target - we should avoid getting payload to TOAST, as it will be deleted anyway.
+<!-- @formatter:on -->
+> > toast_tuple_target - we should avoid getting payload to TOAST, as it will be deleted anyway.
 
-Postgres tries to compress the message when it is large enough (by default 2kb). But because tw-tkms already applies compression, 
+Postgres tries to compress the message when it is large enough (by default 2kb). But because `tw-tkms` already applies compression,
 it will be wasted effort and resources.
 
+<!-- @formatter:off -->
 ```postgresql
 ALTER TABLE outgoing_message_0_0 ALTER COLUMN message SET STORAGE EXTERNAL;
 ```
+<!-- @formatter:on -->
 
 ## Curator setup
+
 TwTkms is relying on [tw-leader-selector](https://github.com/transferwise/tw-leader-selector), which in turn needs a specific
 connection listener to be registered, before the `CuratorFramework` is started.
 
@@ -74,8 +89,9 @@ If you have your own configuration class for creating `CuratorFramework` bean, y
 `tw-leader-selector` is bringing in [tw-curator](https://github.com/transferwise/tw-curator) which does the correct auto configuration by itself.
 
 Just set the following `tw-curator.zookeeper-connect-string` configuration option, and you are done.
- 
+
 For example:
+
 ```yaml
 tw-curator:
   zookeeper-connect-string: "localhost:2181"
@@ -92,6 +108,7 @@ Alternatively, for more complex setups you can provide an `ITkmsDataSourceProvid
 ## Choosing a compression algorithm
 
 A typical transfer change event compressed 100000 times:
+
 ```
 Original size: 3237
 Snappy time: 16057ms.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,14 +37,23 @@ CREATE TABLE outgoing_message_0_0 (
               message MEDIUMBLOB NOT NULL)
               stats_persistent=1, stats_auto_recalc=0 ENGINE=InnoDB;
 
+-- Set engine stats.
 update mysql.innodb_index_stats set stat_value=1000000 where table_name = "outgoing_message_0_0" and stat_description="id";
 update mysql.innodb_table_stats set n_rows=1000000 where table_name like "outgoing_message_0_0";
-flush table outgoing_message_0_0;
+
+-- Set engine independent stats.
+insert into mysql.table_stats (db_name, table_name, cardinality) values(DATABASE(), "outgoing_message_0_0", 1000000)
+                                                                 on duplicate key update cardinality=1000000;
+
+-- Apply the stats to be used for next queries.
+flush tables;
 ```
 <!-- @formatter:on -->
 
-> Make sure you never run ANALYZE on those tables as it will overwrite those stats, and you will end up with database going crazy on certain
+> Make sure you **never** run ANALYZE on those tables as it will overwrite those stats, and you will end up with database going crazy on certain
 > situations.
+
+> We are setting engine independent stats as well, so that a simple ANALYZE would not mess things up.
 
 As some of those commands require specific permissions, you most likely will need some help from DBAs.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,8 +1,6 @@
 # Setup
 
-We are assuming you are using Spring Boot, at least version 2.1.
-
-As usual, we can incorporate it into your Service through [tw-dependency](https://github.com/transferwise/tw-dependencies)
+We are assuming you are using Spring Boot, at least version 2.5.
 
 ```groovy
 implementation 'com.transferwise.kafka:tw-tkms-starter'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.20.0
+version=0.21.0

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/AlgorithmErrorException.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/AlgorithmErrorException.java
@@ -1,0 +1,10 @@
+package com.transferwise.kafka.tkms;
+
+public class AlgorithmErrorException extends RuntimeException {
+
+  static final long serialVersionUID = 1L;
+
+  public AlgorithmErrorException(String message) {
+    super("Algorithm error detected: " + message);
+  }
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/Assertions.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/Assertions.java
@@ -1,0 +1,26 @@
+package com.transferwise.kafka.tkms;
+
+import lombok.Setter;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class Assertions {
+
+  @Setter
+  private static int level = 0;
+
+  public static boolean isEnabled() {
+    return level > -1;
+  }
+
+  public static boolean isLevel1() {
+    return level >= 1;
+  }
+
+  public static void assertAlgorithm(boolean result, String message) {
+    if (!result) {
+      throw new AlgorithmErrorException(message);
+    }
+  }
+
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/IProblemNotifier.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/IProblemNotifier.java
@@ -4,11 +4,12 @@ import com.transferwise.kafka.tkms.config.TkmsProperties.NotificationLevel;
 import java.util.function.Supplier;
 
 /**
- * The main idea here is to allow service teams to "tweak" a leven of specific problems.
+ * The main idea here is to allow service teams to "tweak" the notifications level/action of specific problems.
  */
 public interface IProblemNotifier {
 
-  void notify(String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider);
+  void notify(Integer shard, String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider);
 
-  void notify(String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider, Throwable t);
+  void notify(Integer shard, String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider,
+      Throwable t);
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/IProblemNotifier.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/IProblemNotifier.java
@@ -1,0 +1,14 @@
+package com.transferwise.kafka.tkms;
+
+import com.transferwise.kafka.tkms.config.TkmsProperties.NotificationLevel;
+import java.util.function.Supplier;
+
+/**
+ * The main idea here is to allow service teams to "tweak" a leven of specific problems.
+ */
+public interface IProblemNotifier {
+
+  void notify(String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider);
+
+  void notify(String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider, Throwable t);
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/IProblemNotifier.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/IProblemNotifier.java
@@ -1,6 +1,7 @@
 package com.transferwise.kafka.tkms;
 
 import com.transferwise.kafka.tkms.config.TkmsProperties.NotificationLevel;
+import com.transferwise.kafka.tkms.config.TkmsProperties.NotificationType;
 import java.util.function.Supplier;
 
 /**
@@ -8,8 +9,8 @@ import java.util.function.Supplier;
  */
 public interface IProblemNotifier {
 
-  void notify(Integer shard, String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider);
+  void notify(Integer shard, NotificationType notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider);
 
-  void notify(Integer shard, String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider,
+  void notify(Integer shard, NotificationType notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider,
       Throwable t);
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/ITkmsPaceMaker.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/ITkmsPaceMaker.java
@@ -1,12 +1,15 @@
 package com.transferwise.kafka.tkms;
 
+import com.transferwise.kafka.tkms.api.TkmsShardPartition;
 import java.time.Duration;
 
 public interface ITkmsPaceMaker {
 
   void doSmallPause(int shard);
-
-  void pauseOnError(int shard);
-
+  
   Duration getLongWaitTime(int shard);
+
+  Duration getPollingPause(TkmsShardPartition tkmsShardPartition, int pollingBatchSize, int polledMessagesCount);
+
+  Duration getPollingPauseOnError(TkmsShardPartition tkmsShardPartition);
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/ITkmsPaceMaker.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/ITkmsPaceMaker.java
@@ -6,7 +6,7 @@ import java.time.Duration;
 public interface ITkmsPaceMaker {
 
   void doSmallPause(int shard);
-  
+
   Duration getLongWaitTime(int shard);
 
   Duration getPollingPause(TkmsShardPartition tkmsShardPartition, int pollingBatchSize, int polledMessagesCount);

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/ProblemNotifier.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/ProblemNotifier.java
@@ -13,8 +13,11 @@ public class ProblemNotifier implements IProblemNotifier {
   private TkmsProperties tkmsProperties;
 
   @Override
-  public void notify(String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider, Throwable t) {
-    var notificationLevel = tkmsProperties.getNotificationLevel().get(notificationType);
+  public void notify(Integer shard, String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider, Throwable t) {
+    var notificationLevel = shard == null ?
+        tkmsProperties.getNotificationLevels().get(notificationType)
+        : tkmsProperties.getNotificationLevels(shard, notificationType);
+
     if (notificationLevel == null) {
       notificationLevel = defaultLevel;
     }
@@ -32,7 +35,7 @@ public class ProblemNotifier implements IProblemNotifier {
   }
 
   @Override
-  public void notify(String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider) {
-    notify(notificationType, defaultLevel, messageProvider, null);
+  public void notify(Integer shard, String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider) {
+    notify(shard, notificationType, defaultLevel, messageProvider, null);
   }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/ProblemNotifier.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/ProblemNotifier.java
@@ -1,0 +1,38 @@
+package com.transferwise.kafka.tkms;
+
+import com.transferwise.kafka.tkms.config.TkmsProperties;
+import com.transferwise.kafka.tkms.config.TkmsProperties.NotificationLevel;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Slf4j
+public class ProblemNotifier implements IProblemNotifier {
+
+  @Autowired
+  private TkmsProperties tkmsProperties;
+
+  @Override
+  public void notify(String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider, Throwable t) {
+    var notificationLevel = tkmsProperties.getNotificationLevel().get(notificationType);
+    if (notificationLevel == null) {
+      notificationLevel = defaultLevel;
+    }
+
+    if (notificationLevel == NotificationLevel.INFO) {
+      log.info(messageProvider.get());
+    } else if (notificationLevel == NotificationLevel.WARN) {
+      log.warn(messageProvider.get(), t);
+    } else if (notificationLevel == NotificationLevel.ERROR) {
+      log.error(messageProvider.get(), t);
+    }
+    if (notificationLevel == NotificationLevel.BLOCK) {
+      throw new IllegalStateException(messageProvider.get(), t);
+    }
+  }
+
+  @Override
+  public void notify(String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider) {
+    notify(notificationType, defaultLevel, messageProvider, null);
+  }
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/ProblemNotifier.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/ProblemNotifier.java
@@ -2,6 +2,7 @@ package com.transferwise.kafka.tkms;
 
 import com.transferwise.kafka.tkms.config.TkmsProperties;
 import com.transferwise.kafka.tkms.config.TkmsProperties.NotificationLevel;
+import com.transferwise.kafka.tkms.config.TkmsProperties.NotificationType;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,9 +14,10 @@ public class ProblemNotifier implements IProblemNotifier {
   private TkmsProperties tkmsProperties;
 
   @Override
-  public void notify(Integer shard, String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider, Throwable t) {
-    var notificationLevel = shard == null ?
-        tkmsProperties.getNotificationLevels().get(notificationType)
+  public void notify(Integer shard, NotificationType notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider,
+      Throwable t) {
+    var notificationLevel = shard == null
+        ? tkmsProperties.getNotificationLevels().get(notificationType)
         : tkmsProperties.getNotificationLevels(shard, notificationType);
 
     if (notificationLevel == null) {
@@ -35,7 +37,7 @@ public class ProblemNotifier implements IProblemNotifier {
   }
 
   @Override
-  public void notify(Integer shard, String notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider) {
+  public void notify(Integer shard, NotificationType notificationType, NotificationLevel defaultLevel, Supplier<String> messageProvider) {
     notify(shard, notificationType, defaultLevel, messageProvider, null);
   }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsClockHolder.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsClockHolder.java
@@ -19,6 +19,6 @@ public class TkmsClockHolder {
   }
 
   private TkmsClockHolder() {
-    
+
   }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsPaceMaker.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsPaceMaker.java
@@ -34,7 +34,10 @@ public class TkmsPaceMaker implements ITkmsPaceMaker {
   public Duration getPollingPause(TkmsShardPartition shardPartition, int pollingBatchSize, int polledMessagesCount) {
     long maxPollIntervalMs = properties.getPollingInterval(shardPartition.getShard()).toMillis();
 
-    return Duration.ofMillis(maxPollIntervalMs * (pollingBatchSize - polledMessagesCount) / pollingBatchSize);
+    var pollingPause = Duration.ofMillis(maxPollIntervalMs * (pollingBatchSize - polledMessagesCount) / pollingBatchSize);
+    var minPollingInterval = properties.getMinPollingInterval();
+
+    return minPollingInterval == null || minPollingInterval.compareTo(pollingPause) > 0 ? pollingPause : minPollingInterval;
   }
 
   @Override

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsStorageToKafkaProxy.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsStorageToKafkaProxy.java
@@ -181,7 +181,7 @@ public class TkmsStorageToKafkaProxy implements GracefulShutdownStrategy, ITkmsS
                 polledRecordsCount = records.size();
                 if (polledRecordsCount == 0) {
                   metricsTemplate.recordProxyPoll(shardPartition, 0, cycleStartNanoTime);
-                  proxyCyclePauseRequest.setValue(tkmsPaceMaker.getPollingPause(shardPartition, pollerBatchSize, 0));
+                  proxyCyclePauseRequest.setValue(tkmsPaceMaker.getPollingPause(shardPartition, pollerBatchSize, polledRecordsCount));
                   return;
                 }
 
@@ -289,6 +289,8 @@ public class TkmsStorageToKafkaProxy implements GracefulShutdownStrategy, ITkmsS
 
                 if (failedSendsCount.get() > 0) {
                   proxyCyclePauseRequest.setValue(tkmsPaceMaker.getPollingPauseOnError(shardPartition));
+                } else {
+                  proxyCyclePauseRequest.setValue(tkmsPaceMaker.getPollingPause(shardPartition, pollerBatchSize, polledRecordsCount));
                 }
               } catch (Throwable t) {
                 log.error(t.getMessage(), t);

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSender.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSender.java
@@ -59,6 +59,8 @@ public class TransactionalKafkaMessageSender implements ITransactionalKafkaMessa
 
   @PostConstruct
   public void init() {
+    Assertions.setLevel(properties.getInternals().getAssertionLevel());
+
     environmentValidator.validate();
 
     for (String topic : properties.getTopics()) {
@@ -108,13 +110,13 @@ public class TransactionalKafkaMessageSender implements ITransactionalKafkaMessa
       int size = batchSizes.get(i);
 
       if (size < 1) {
-        throw new IllegalStateException("Invalid delete batch sizes provided for '" + subject + "', " + size + "<1 .");
+        throw new IllegalStateException("Invalid delete batch sizes provided for '" + subject + "', " + size + "<1.");
       }
 
       if (i > 0) {
         int prevSize = batchSizes.get(i - 1);
         if (prevSize <= size) {
-          throw new IllegalStateException("Invalid delete batch sizes provided for '" + subject + "', " + prevSize + "<=" + size + " .");
+          throw new IllegalStateException("Invalid delete batch sizes provided for '" + subject + "', " + prevSize + "<=" + size + ".");
         }
       }
     }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSender.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSender.java
@@ -14,7 +14,7 @@ import com.transferwise.kafka.tkms.config.ITkmsKafkaProducerProvider;
 import com.transferwise.kafka.tkms.config.TkmsProperties;
 import com.transferwise.kafka.tkms.config.TkmsProperties.DatabaseDialect;
 import com.transferwise.kafka.tkms.config.TkmsProperties.NotificationLevel;
-import com.transferwise.kafka.tkms.config.TkmsProperties.Notifications;
+import com.transferwise.kafka.tkms.config.TkmsProperties.NotificationType;
 import com.transferwise.kafka.tkms.dao.ITkmsDao;
 import com.transferwise.kafka.tkms.dao.ITkmsDao.InsertMessageResult;
 import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
@@ -75,7 +75,7 @@ public class TransactionalKafkaMessageSender implements ITransactionalKafkaMessa
       if (properties.getDatabaseDialect(s) == DatabaseDialect.POSTGRES) {
         if (!properties.getEarliestVisibleMessages(s).isEnabled()) {
           int shard = s;
-          problemNotifier.notify(s, Notifications.EARLIEST_MESSAGES_SYSTEM_DISABLED, NotificationLevel.ERROR, () ->
+          problemNotifier.notify(s, NotificationType.EARLIEST_MESSAGES_SYSTEM_DISABLED, NotificationLevel.ERROR, () ->
               "Earliest messages system is not enabled for a Postgres database on shard " + shard + ". This can create a serious"
                   + " performance issue when autovacuum gets behind."
           );
@@ -100,7 +100,7 @@ public class TransactionalKafkaMessageSender implements ITransactionalKafkaMessa
     }
 
     if (batchSizes.size() > 10) {
-      problemNotifier.notify(shard, Notifications.TOO_MANY_DELETE_BATCHES, NotificationLevel.WARN,
+      problemNotifier.notify(shard, NotificationType.TOO_MANY_DELETE_BATCHES, NotificationLevel.WARN,
           () -> "Too many delete batches (" + batchSizes.size() + ") can create metrics with too high cardinality.");
     }
 

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSender.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSender.java
@@ -75,7 +75,7 @@ public class TransactionalKafkaMessageSender implements ITransactionalKafkaMessa
       if (properties.getDatabaseDialect(s) == DatabaseDialect.POSTGRES) {
         if (!properties.getEarliestVisibleMessages(s).isEnabled()) {
           int shard = s;
-          problemNotifier.notify(Notifications.EARLIEST_MESSAGES_SYSTEM_DISABLED, NotificationLevel.ERROR, () ->
+          problemNotifier.notify(s, Notifications.EARLIEST_MESSAGES_SYSTEM_DISABLED, NotificationLevel.ERROR, () ->
               "Earliest messages system is not enabled for a Postgres database on shard " + shard + ". This can create a serious"
                   + " performance issue when autovacuum gets behind."
           );
@@ -86,11 +86,11 @@ public class TransactionalKafkaMessageSender implements ITransactionalKafkaMessa
 
   protected void validateDeleteBatchSizes() {
     for (int s = 0; s < properties.getShardsCount(); s++) {
-      validateDeleteBatchSize(properties.getDeleteBatchSizes(s), "shard " + s);
+      validateDeleteBatchSize(s, properties.getDeleteBatchSizes(s), "shard " + s);
     }
   }
 
-  protected void validateDeleteBatchSize(List<Integer> batchSizes, String subject) {
+  protected void validateDeleteBatchSize(int shard, List<Integer> batchSizes, String subject) {
     if (batchSizes == null || batchSizes.isEmpty()) {
       throw new IllegalStateException("Invalid delete batch sizes provided for '" + subject + "', no batches provided.");
     }
@@ -100,7 +100,7 @@ public class TransactionalKafkaMessageSender implements ITransactionalKafkaMessa
     }
 
     if (batchSizes.size() > 10) {
-      problemNotifier.notify(Notifications.TOO_MANY_DELETE_BATCHES, NotificationLevel.WARN,
+      problemNotifier.notify(shard, Notifications.TOO_MANY_DELETE_BATCHES, NotificationLevel.WARN,
           () -> "Too many delete batches (" + batchSizes.size() + ") can create metrics with too high cardinality.");
     }
 

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsConfiguration.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsConfiguration.java
@@ -4,9 +4,11 @@ import com.transferwise.common.baseutils.meters.cache.IMeterCache;
 import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHelper;
 import com.transferwise.kafka.tkms.EnvironmentValidator;
 import com.transferwise.kafka.tkms.IEnvironmentValidator;
+import com.transferwise.kafka.tkms.IProblemNotifier;
 import com.transferwise.kafka.tkms.ITkmsPaceMaker;
 import com.transferwise.kafka.tkms.ITkmsStorageToKafkaProxy;
 import com.transferwise.kafka.tkms.ITkmsZookeeperOperations;
+import com.transferwise.kafka.tkms.ProblemNotifier;
 import com.transferwise.kafka.tkms.TkmsMessageInterceptors;
 import com.transferwise.kafka.tkms.TkmsPaceMaker;
 import com.transferwise.kafka.tkms.TkmsStorageToKafkaProxy;
@@ -66,12 +68,12 @@ public class TkmsConfiguration {
   @Bean
   @ConditionalOnMissingBean(ITkmsDao.class)
   public TkmsDao tkmsDao(ITkmsDataSourceProvider dataSourceProvider, TkmsProperties tkmsProperties,
-                         ITkmsMetricsTemplate metricsTemplate, ITkmsMessageSerializer messageSerializer,
-                         ITransactionsHelper transactionsHelper) {
+      ITkmsMetricsTemplate metricsTemplate, ITkmsMessageSerializer messageSerializer,
+      ITransactionsHelper transactionsHelper, IProblemNotifier problemNotifier) {
     if (tkmsProperties.getDatabaseDialect() == DatabaseDialect.POSTGRES) {
-      return new TkmsPostgresDao(dataSourceProvider, tkmsProperties, metricsTemplate, messageSerializer,transactionsHelper);
+      return new TkmsPostgresDao(dataSourceProvider, tkmsProperties, metricsTemplate, messageSerializer, transactionsHelper, problemNotifier);
     }
-    return new TkmsMariaDao(dataSourceProvider, tkmsProperties, metricsTemplate, messageSerializer,transactionsHelper);
+    return new TkmsMariaDao(dataSourceProvider, tkmsProperties, metricsTemplate, messageSerializer, transactionsHelper, problemNotifier);
   }
 
   @Bean
@@ -159,4 +161,9 @@ public class TkmsConfiguration {
     return new TkmsClusterWideStateMonitor();
   }
 
+  @Bean
+  @ConditionalOnMissingBean(IProblemNotifier.class)
+  public ProblemNotifier tkmsProblemNotifier() {
+    return new ProblemNotifier();
+  }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -23,7 +23,12 @@ public class TkmsProperties {
     TkmsShardPartition.init(this);
   }
 
-  private Map<String, NotificationLevel> notificationLevel = new HashMap<>();
+  /**
+   * Allows to set notification level for different problems the library is detecting.
+   *
+   * <p>The set of keys is described with Notifications class below.
+   */
+  private Map<String, NotificationLevel> notificationLevels = new HashMap<>();
 
   /**
    * Provides more metrics at performance penalty.
@@ -200,7 +205,8 @@ public class TkmsProperties {
     private Compression compression = new Compression();
     private EarliestVisibleMessages earliestVisibleMessages;
     private Boolean requireTransactionOnMessagesRegistering;
-    private List<Integer> deleteBatchSizes = List.of(1024, 256, 64, 16, 4, 1);
+    private List<Integer> deleteBatchSizes;
+    private Map<String, NotificationLevel> notificationLevels = new HashMap<>();
 
     private Map<String, String> kafka = new HashMap<>();
   }
@@ -293,6 +299,14 @@ public class TkmsProperties {
 
     return deleteBatchSizes;
   }
+  
+  public NotificationLevel getNotificationLevels(int shard, String type) {
+    ShardProperties shardProperties = shards.get(shard);
+    if (shardProperties.notificationLevels.get(type) != null) {
+      return shardProperties.notificationLevels.get(type);
+    }
+    return notificationLevels.get(type);
+  }
 
   public enum DatabaseDialect {
     POSTGRES,
@@ -353,6 +367,9 @@ public class TkmsProperties {
     BLOCK
   }
 
+  /*
+    Basically similar idea, what Spotbugs/Checkstyle are using to "hide" unwanted warnings.
+   */
   public static class Notifications {
 
     public static final String INDEX_HINTS_NOT_AVAILABLE = "INDEX_HINTS_NOT_AVAILABLE";

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.PostConstruct;
+import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
@@ -24,9 +25,9 @@ public class TkmsProperties {
   }
 
   /**
-   * Allows to set notification level for different problems the library is detecting.
+   * Allows to set notification level or even block the startup, for different problems the library is detecting.
    *
-   * <p>The set of keys is described with Notifications class below.
+   * <p>The set of keys is described with NotificationType class below.
    */
   private Map<NotificationType, NotificationLevel> notificationLevels = new HashMap<>();
 
@@ -189,6 +190,10 @@ public class TkmsProperties {
    * Validation requires quite specific privileges in database. Some teams may need to turn it off.
    */
   private boolean tableStatsValidationEnabled = true;
+
+  @Valid
+  @NotNull
+  private Internals internals = new Internals();
 
   @Data
   @Accessors(chain = true)
@@ -360,6 +365,18 @@ public class TkmsProperties {
     private Duration leftOverMessagesCheckStartDelay = Duration.ofHours(1);
   }
 
+  /**
+   * Internal toggles for fine-tuning and debugging/testing reasons.
+   *
+   * <p>Do not touch!
+   */
+  @Data
+  @Accessors(chain = true)
+  public static class Internals {
+
+    private int assertionLevel = 0;
+  }
+
   public enum NotificationLevel {
     INFO,
     WARN,
@@ -368,7 +385,7 @@ public class TkmsProperties {
   }
 
   /*
-    Basically similar idea, what Spotbugs/Checkstyle are using to "hide" unwanted warnings.
+    Basically similar idea, what Spotbugs/Checkstyle use to "hide" unwanted warnings.
    */
   public enum NotificationType {
 

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -28,7 +28,7 @@ public class TkmsProperties {
    *
    * <p>The set of keys is described with Notifications class below.
    */
-  private Map<String, NotificationLevel> notificationLevels = new HashMap<>();
+  private Map<NotificationType, NotificationLevel> notificationLevels = new HashMap<>();
 
   /**
    * Provides more metrics at performance penalty.
@@ -206,7 +206,7 @@ public class TkmsProperties {
     private EarliestVisibleMessages earliestVisibleMessages;
     private Boolean requireTransactionOnMessagesRegistering;
     private List<Integer> deleteBatchSizes;
-    private Map<String, NotificationLevel> notificationLevels = new HashMap<>();
+    private Map<NotificationType, NotificationLevel> notificationLevels = new HashMap<>();
 
     private Map<String, String> kafka = new HashMap<>();
   }
@@ -299,10 +299,10 @@ public class TkmsProperties {
 
     return deleteBatchSizes;
   }
-  
-  public NotificationLevel getNotificationLevels(int shard, String type) {
+
+  public NotificationLevel getNotificationLevels(int shard, NotificationType type) {
     ShardProperties shardProperties = shards.get(shard);
-    if (shardProperties.notificationLevels.get(type) != null) {
+    if (shardProperties != null && shardProperties.notificationLevels.get(type) != null) {
       return shardProperties.notificationLevels.get(type);
     }
     return notificationLevels.get(type);
@@ -370,13 +370,15 @@ public class TkmsProperties {
   /*
     Basically similar idea, what Spotbugs/Checkstyle are using to "hide" unwanted warnings.
    */
-  public static class Notifications {
+  public enum NotificationType {
 
-    public static final String INDEX_HINTS_NOT_AVAILABLE = "INDEX_HINTS_NOT_AVAILABLE";
-    public static final String TABLE_STATS_NOT_FIXED = "TABLE_STATS_NOT_FIXED";
-    public static final String INDEX_STATS_NOT_FIXED = "INDEX_STATS_NOT_FIXED";
-    public static final String TABLE_INDEX_STATS_CHECK_ERROR = "TABLE_INDEX_STATS_CHECK_ERROR";
-    public static final String TOO_MANY_DELETE_BATCHES = "TOO_MANY_DELETE_BATCHES";
-    public static final String EARLIEST_MESSAGES_SYSTEM_DISABLED = "EARLIEST_MESSAGES_SYSTEM_DISABLED";
+    INDEX_HINTS_NOT_AVAILABLE,
+    TABLE_STATS_NOT_FIXED,
+    ENGINE_INDEPENDENT_TABLE_STATS_NOT_FIXED,
+    INDEX_STATS_NOT_FIXED,
+    TABLE_INDEX_STATS_CHECK_ERROR,
+    TOO_MANY_DELETE_BATCHES,
+    EARLIEST_MESSAGES_SYSTEM_DISABLED,
+    ENGINE_INDEPENDENT_STATS_NOT_ENABLED
   }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
@@ -288,7 +288,7 @@ public abstract class TkmsDao implements ITkmsDao {
         ps.setLong(2, maxCount);
       }, (rs, rowNum) -> rs.getString(1));
       var explainPlan = concatStringRows(explainPlanRows);
-      Assertions.assertAlgorithm(isUsingIndexScan(explainPlan), "inefficient query plan is used.");
+      Assertions.assertAlgorithm(isUsingIndexScan(explainPlan), "inefficient query plan is used: " + explainPlan);
     }
 
     return result;
@@ -354,7 +354,7 @@ public abstract class TkmsDao implements ITkmsDao {
     if (Assertions.isLevel1()) {
       var rows = jdbcTemplate.queryForList(getExplainClause() + " " + sql, String.class, messageId);
       var explainPlan = concatStringRows(rows);
-      Assertions.assertAlgorithm(isUsingIndexScan(explainPlan), "inefficient query plan is used.");
+      Assertions.assertAlgorithm(isUsingIndexScan(explainPlan), "inefficient query plan is used: " + explainPlan);
     }
 
     return result;
@@ -389,7 +389,7 @@ public abstract class TkmsDao implements ITkmsDao {
             }
           }, (rs, rowNum) -> rs.getString(1));
           var explainPlan = concatStringRows(explainPlanRows);
-          Assertions.assertAlgorithm(isUsingIndexScan(explainPlan), "inefficient query plan is used.");
+          Assertions.assertAlgorithm(isUsingIndexScan(explainPlan), "inefficient query plan is used: " + explainPlan);
         }
 
         processedCount += batchSize;

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
@@ -175,8 +175,29 @@ public class TkmsMariaDao extends TkmsDao {
   }
 
   @Override
+  protected String getEarliestMessageIdSql(TkmsShardPartition shardPartition) {
+    var earliestVisibleMessages = properties.getEarliestVisibleMessages(shardPartition.getShard());
+    return "select message_id from " + earliestVisibleMessages.getTableName() + " use index(PRIMARY) where shard=? and part=?";
+  }
+
+  @Override
   protected String getSelectSql(TkmsShardPartition shardPartition) {
     return "select id, message from " + getTableName(shardPartition) + " use index (PRIMARY) where id >= ? order by id limit ?";
+  }
+
+  @Override
+  protected String getHasMessagesBeforeIdSql(TkmsShardPartition shardPartition) {
+    return "select 1 from " + getTableName(shardPartition) + " use index(PRIMARY) where id < ? limit 1";
+  }
+
+  @Override
+  protected String getExplainClause() {
+    return "EXPLAIN FORMAT=JSON";
+  }
+
+  @Override
+  protected boolean isUsingIndexScan(String sql) {
+    return sql.contains("\"key\": \"PRIMARY\"");
   }
 
   @Override

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
@@ -1,28 +1,36 @@
 package com.transferwise.kafka.tkms.dao;
 
 import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHelper;
+import com.transferwise.kafka.tkms.IProblemNotifier;
 import com.transferwise.kafka.tkms.api.TkmsShardPartition;
 import com.transferwise.kafka.tkms.config.ITkmsDataSourceProvider;
 import com.transferwise.kafka.tkms.config.TkmsProperties;
+import com.transferwise.kafka.tkms.config.TkmsProperties.NotificationLevel;
+import com.transferwise.kafka.tkms.config.TkmsProperties.Notifications;
 import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
 import com.transferwise.kafka.tkms.metrics.MonitoringQuery;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.dao.DataAccessException;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 public class TkmsMariaDao extends TkmsDao {
 
+  private final IProblemNotifier problemNotifier;
+
   public TkmsMariaDao(
       ITkmsDataSourceProvider dataSourceProvider,
       TkmsProperties properties,
       ITkmsMetricsTemplate metricsTemplate,
       ITkmsMessageSerializer messageSerializer,
-      ITransactionsHelper transactionsHelper
+      ITransactionsHelper transactionsHelper,
+      IProblemNotifier problemNotifier
   ) {
     super(dataSourceProvider, properties, metricsTemplate, messageSerializer, transactionsHelper);
+    this.problemNotifier = problemNotifier;
   }
 
   @Override
@@ -31,12 +39,13 @@ public class TkmsMariaDao extends TkmsDao {
   public long getApproximateMessagesCount(TkmsShardPartition sp) {
     List<Long> rows =
         jdbcTemplate.queryForList("select table_rows from information_schema.tables where table_schema=? and table_name = ?", Long.class,
-        getSchemaName(sp), getTableNameWithoutSchema(sp));
+            getSchemaName(sp), getTableNameWithoutSchema(sp));
 
     return rows.isEmpty() ? -1 : rows.get(0);
   }
 
-  protected void validateEngineSpecificSchema() {
+  @Override
+  protected void validateEngineSpecifics() {
     if (!properties.isTableStatsValidationEnabled()) {
       return;
     }
@@ -47,19 +56,32 @@ public class TkmsMariaDao extends TkmsDao {
           TkmsShardPartition sp = TkmsShardPartition.of(s, p);
 
           long rowsInTableStats = getRowsFromTableStats(sp);
-          long rowsInIndexStats = getRowsFromIndexStats(sp);
+          metricsTemplate.registerRowsInTableStats(sp, rowsInTableStats);
 
-          if (rowsInTableStats < 100000 || rowsInIndexStats < 100000) {
-            log.warn("Table for " + sp + " is not properly configured. Rows from table stats is " + rowsInTableStats + ", rows in index stats is "
-                + rowsInIndexStats + ". This can greatly affect performance during peaks or database slownesses.");
+          // Default log level should be at least error, because misconfiguration here can take down your database.
+          if (rowsInTableStats < 1000000) {
+            problemNotifier.notify(Notifications.TABLE_STATS_NOT_FIXED, NotificationLevel.ERROR, () ->
+                "Table for " + sp + " is not properly configured. Rows from table stats is " + rowsInTableStats + "."
+                    + "This can greatly affect performance of DELETE queries during peaks or database slowness. Please check the setup guide how "
+                    + "to fix table stats."
+            );
           }
 
-          metricsTemplate.registerRowsInTableStats(sp, rowsInTableStats);
+          long rowsInIndexStats = getRowsFromIndexStats(sp);
           metricsTemplate.registerRowsInIndexStats(sp, rowsInIndexStats);
+
+          if (rowsInIndexStats < 1000000) {
+            problemNotifier.notify(Notifications.INDEX_STATS_NOT_FIXED, NotificationLevel.ERROR, () ->
+                "Table for " + sp + " is not properly configured. Rows in index stats is " + rowsInIndexStats + "."
+                    + " This can greatly affect performance of DELETE queries during peaks or database slowness. Please check the setup guide how "
+                    + "to fix index stats."
+            );
+          }
         }
       }
-    } catch (Throwable t) {
-      log.error("Validating table and index stats failed. Will still continue with the initialization.", t);
+    } catch (DataAccessException dae) {
+      problemNotifier.notify(Notifications.TABLE_INDEX_STATS_CHECK_ERROR, NotificationLevel.BLOCK, () ->
+          "Validating table and index stats failed. Will still continue with the initialization.", dae);
     }
   }
 
@@ -84,27 +106,55 @@ public class TkmsMariaDao extends TkmsDao {
     return stats.get(0);
   }
 
+  @Override
   protected boolean doesEarliestVisibleMessagesTableExist() {
-    String schema = currentSchema;
-    String table = properties.getEarliestVisibleMessages().getTableName();
-    if (StringUtils.contains(table, ".")) {
-      schema = StringUtils.substringBefore(table, ".");
-      table = StringUtils.substringAfter(table, ".");
+    String schema;
+    String table;
+    var defaultTable = properties.getEarliestVisibleMessages().getTableName();
+    if (StringUtils.contains(defaultTable, ".")) {
+      schema = StringUtils.substringBefore(defaultTable, ".");
+      table = StringUtils.substringAfter(defaultTable, ".");
+    } else {
+      schema = currentSchema;
+      table = defaultTable;
     }
 
-    return !jdbcTemplate.queryForList("SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", Boolean.class,
-      schema, table).isEmpty();
+    return transactionsHelper.withTransaction().asNew().withIsolation(Isolation.READ_UNCOMMITTED).call(
+        () -> !jdbcTemplate.queryForList("SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", Boolean.class,
+            schema, table).isEmpty()
+    );
   }
 
+  @Override
   protected String getInsertSql(TkmsShardPartition shardPartition) {
     return "insert into " + getTableName(shardPartition) + " (message) values (?)";
   }
 
+  @Override
   protected String getSelectSql(TkmsShardPartition shardPartition) {
     return "select id, message from " + getTableName(shardPartition) + " use index (PRIMARY) where id >= ? order by id limit ?";
   }
 
+  @Override
+  protected String getDeleteSql(TkmsShardPartition shardPartition, int batchSize) {
+    // MariaDb does not support index hints for delete queries.
+    // But MySQL does, so we will still include it in the query.
+    var sb = new StringBuilder("delete /*+ INDEX(outgoing_message_0_0) */ from " + getTableName(shardPartition) + " where id in (");
+    for (int j = 0; j < batchSize; j++) {
+      if (j > 0) {
+        sb.append(",");
+      }
+      sb.append("?");
+    }
+    sb.append(")");
+
+    return sb.toString();
+  }
+
+  @Override
   protected String getCurrentSchema() {
-    return jdbcTemplate.queryForObject("select DATABASE()", String.class);
+    return transactionsHelper.withTransaction().withIsolation(Isolation.READ_UNCOMMITTED).call(() ->
+        jdbcTemplate.queryForObject("select DATABASE()", String.class)
+    );
   }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
@@ -50,7 +50,7 @@ public class TkmsPostgresDao extends TkmsDao {
 
   @Override
   protected String getHasMessagesBeforeIdSql(TkmsShardPartition shardPartition) {
-    return "select /*+ IndexOnlyScan(om) */ 1 from " + getTableName(shardPartition) + " om where id < ? limit 1";
+    return "select /*+ IndexOnlyScan(om) */ 1 from " + getTableName(shardPartition) + " om where id < ? order by id desc limit 1";
   }
 
   @Override

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
@@ -50,7 +50,7 @@ public class TkmsPostgresDao extends TkmsDao {
 
   @Override
   protected String getHasMessagesBeforeIdSql(TkmsShardPartition shardPartition) {
-    return "select /*+ IndexScan(om) 1 from " + getTableName(shardPartition) + " om where id < ? limit 1";
+    return "select /*+ IndexOnlyScan(om) */ 1 from " + getTableName(shardPartition) + " om where id < ? limit 1";
   }
 
   @Override
@@ -205,13 +205,4 @@ public class TkmsPostgresDao extends TkmsDao {
     }
   }
 
-  @Override
-  @MonitoringQuery
-  @Transactional(rollbackFor = Exception.class, isolation = Isolation.READ_UNCOMMITTED)
-  public boolean hasMessagesBeforeId(TkmsShardPartition shardPartition, Long messageId) {
-    List<Long> exists =
-        jdbcTemplate.queryForList("select /*+ IndexOnlyScan(om) */ 1 from " + getTableName(shardPartition) + " om where id < ? limit 1", Long.class,
-            messageId);
-    return !exists.isEmpty();
-  }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
@@ -2,10 +2,14 @@ package com.transferwise.kafka.tkms.dao;
 
 import com.google.common.primitives.Longs;
 import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHelper;
+import com.transferwise.kafka.tkms.IProblemNotifier;
 import com.transferwise.kafka.tkms.api.TkmsShardPartition;
 import com.transferwise.kafka.tkms.config.ITkmsDataSourceProvider;
 import com.transferwise.kafka.tkms.config.TkmsProperties;
+import com.transferwise.kafka.tkms.config.TkmsProperties.NotificationLevel;
+import com.transferwise.kafka.tkms.config.TkmsProperties.Notifications;
 import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
+import com.transferwise.kafka.tkms.metrics.MonitoringQuery;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -17,14 +21,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class TkmsPostgresDao extends TkmsDao {
 
+  private final IProblemNotifier problemNotifier;
+
   public TkmsPostgresDao(
       ITkmsDataSourceProvider dataSourceProvider,
       TkmsProperties properties,
       ITkmsMetricsTemplate metricsTemplate,
       ITkmsMessageSerializer messageSerializer,
-      ITransactionsHelper transactionsHelper
+      ITransactionsHelper transactionsHelper,
+      IProblemNotifier problemNotifier
   ) {
     super(dataSourceProvider, properties, metricsTemplate, messageSerializer, transactionsHelper);
+    this.problemNotifier = problemNotifier;
   }
 
   public static final Pattern N_DISTINCT_PATTERN = Pattern.compile("n_distinct=(.*)[,}]");
@@ -36,29 +44,52 @@ public class TkmsPostgresDao extends TkmsDao {
 
   @Override
   protected String getSelectSql(TkmsShardPartition shardPartition) {
-    return "select id, message from " + getTableName(shardPartition) + " where id >= ? order by id limit ?";
+    return "select /*+ IndexScan(om) */ id, message from " + getTableName(shardPartition) + " om where id >= ? order by id limit ?";
+  }
+
+  @Override
+  protected String getDeleteSql(TkmsShardPartition shardPartition, int batchSize) {
+    var sb = new StringBuilder("delete /*+ IndexScan(om) */ from " + getTableName(shardPartition) + " om where id in (");
+    for (int j = 0; j < batchSize; j++) {
+      if (j > 0) {
+        sb.append(",");
+      }
+      sb.append("?");
+    }
+    sb.append(")");
+
+    return sb.toString();
   }
 
   @Override
   protected boolean doesEarliestVisibleMessagesTableExist() {
-    String schema = currentSchema;
-    String table = properties.getEarliestVisibleMessages().getTableName();
-    if (StringUtils.contains(table, ".")) {
-      schema = StringUtils.substringBefore(table, ".");
-      table = StringUtils.substringAfter(table, ".");
+    var defaultTable = properties.getEarliestVisibleMessages().getTableName();
+
+    String schema;
+    String table;
+    if (StringUtils.contains(defaultTable, ".")) {
+      schema = StringUtils.substringBefore(defaultTable, ".");
+      table = StringUtils.substringAfter(defaultTable, ".");
+    } else {
+      schema = currentSchema;
+      table = defaultTable;
     }
 
-    return !jdbcTemplate.queryForList("SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", String.class,
-      schema, table).isEmpty();
+    return transactionsHelper.withTransaction().asNew().withIsolation(Isolation.READ_UNCOMMITTED).call(() ->
+        !jdbcTemplate.queryForList("SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", String.class,
+            schema, table).isEmpty()
+    );
   }
 
   @Override
   protected String getCurrentSchema() {
-    return jdbcTemplate.queryForObject("select current_schema()", String.class);
+    return transactionsHelper.withTransaction().asNew().withIsolation(Isolation.READ_UNCOMMITTED).call(() ->
+        jdbcTemplate.queryForObject("select current_schema()", String.class)
+    );
   }
 
   @Override
-  protected void validateEngineSpecificSchema() {
+  protected void validateEngineSpecifics() {
     if (!properties.isTableStatsValidationEnabled()) {
       return;
     }
@@ -71,7 +102,7 @@ public class TkmsPostgresDao extends TkmsDao {
           long distinctIdsCount = getDistinctIdsCount(sp);
           if (distinctIdsCount < 100000) {
             log.warn("Table for " + sp + " is not properly configured. Rows from table stats is " + distinctIdsCount
-                + ". This can greatly affect performance during peaks or database slownesses.");
+                + ". This can greatly affect performance during peaks or database slowness.");
           }
 
           metricsTemplate.registerRowsInTableStats(sp, distinctIdsCount);
@@ -80,6 +111,38 @@ public class TkmsPostgresDao extends TkmsDao {
     } catch (Throwable t) {
       log.error("Validating table and index stats failed. Will still continue with the initialization.", t);
     }
+
+    validateIndexHints();
+  }
+
+  protected void validateIndexHints() {
+    var seqScans = doesRespectHint("SeqScan", "Seq Scan");
+    var indexOnlyScans = doesRespectHint("IndexOnlyScan", "Index Only Scan");
+
+    if (!seqScans || !indexOnlyScans) {
+      // By default, logged as ERROR, as it can cause pretty serious problems.
+      problemNotifier.notify(Notifications.INDEX_HINTS_NOT_AVAILABLE, NotificationLevel.ERROR,
+          () -> "Query hints are not supported. This can greatly affect performance during peaks or database slowness. Make sure `pg_hint_plan` "
+              + "extension is available.");
+    }
+  }
+
+  protected boolean doesRespectHint(String hint, String expectedPlan) {
+    var table = getTableName(TkmsShardPartition.of(0, 0));
+    var explainResult = getExplainResult("select /*+ " + hint + "(om) */ id from " + table + " om where id = 1");
+    return explainResult.contains(expectedPlan);
+  }
+
+  protected String getExplainResult(String sql) {
+    var rows = jdbcTemplate.queryForList("EXPLAIN " + sql, String.class);
+    var sb = new StringBuilder();
+    for (int i = 0; i < rows.size(); i++) {
+      if (i > 0) {
+        sb.append("\n");
+      }
+      sb.append(rows.get(i));
+    }
+    return sb.toString();
   }
 
   @Override
@@ -87,17 +150,18 @@ public class TkmsPostgresDao extends TkmsDao {
   public long getApproximateMessagesCount(TkmsShardPartition sp) {
     List<Long> rows =
         jdbcTemplate.queryForList("SELECT reltuples as approximate_row_count FROM pg_class, pg_namespace WHERE "
-            + " pg_class.relnamespace=pg_namespace.oid and nspname=? and relname = ?", Long.class,
-        getSchemaName(sp), getTableNameWithoutSchema(sp));
+                + " pg_class.relnamespace=pg_namespace.oid and nspname=? and relname = ?", Long.class,
+            getSchemaName(sp), getTableNameWithoutSchema(sp));
 
     return rows.isEmpty() ? -1 : rows.get(0);
   }
 
   protected long getDistinctIdsCount(TkmsShardPartition sp) {
-    List<String> relOptionsList =
-          jdbcTemplate.queryForList("select attoptions from pg_attribute, pg_class, pg_namespace where pg_class.oid = pg_attribute.attrelid "
-          + "and pg_class.relnamespace = pg_namespace.oid "
-          + "and pg_namespace.nspname=? and pg_class.relname=? and attname='id'", String.class, getSchemaName(sp), getTableNameWithoutSchema(sp));
+    List<String> relOptionsList = transactionsHelper.withTransaction().asNew().withIsolation(Isolation.READ_UNCOMMITTED).call(() ->
+        jdbcTemplate.queryForList("select attoptions from pg_attribute, pg_class, pg_namespace where pg_class.oid = pg_attribute.attrelid "
+            + "and pg_class.relnamespace = pg_namespace.oid "
+            + "and pg_namespace.nspname=? and pg_class.relname=? and attname='id'", String.class, getSchemaName(sp), getTableNameWithoutSchema(sp))
+    );
 
     if (relOptionsList.isEmpty()) {
       return -1;
@@ -113,5 +177,14 @@ public class TkmsPostgresDao extends TkmsDao {
     } else {
       return -1;
     }
+  }
+
+  @Override
+  @MonitoringQuery
+  @Transactional(rollbackFor = Exception.class, isolation = Isolation.READ_UNCOMMITTED)
+  public boolean hasMessagesBeforeId(TkmsShardPartition sp, Long messageId) {
+    List<Long> exists =
+        jdbcTemplate.queryForList("select /*+ IndexOnlyScan */ 1 from " + getTableName(sp) + " om where id < ? limit 1", Long.class, messageId);
+    return !exists.isEmpty();
   }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/ITkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/ITkmsMetricsTemplate.java
@@ -43,7 +43,7 @@ public interface ITkmsMetricsTemplate {
   Object registerEarliestMessageId(TkmsShardPartition shardPartition, Supplier<Number> supplier);
 
   void registerRowsInTableStats(TkmsShardPartition sp, long rowsInTableStats);
-  
+
   void registerRowsInEngineIndependentTableStats(TkmsShardPartition sp, long rowsInTableStats);
 
   void registerRowsInIndexStats(TkmsShardPartition sp, long rowsInIndexStats);

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/ITkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/ITkmsMetricsTemplate.java
@@ -51,4 +51,6 @@ public interface ITkmsMetricsTemplate {
   Object registerApproximateMessagesCount(TkmsShardPartition sp, Supplier<Number> supplier);
 
   void registerEarliestMessageIdCommit(TkmsShardPartition shardPartition);
+
+  void recordProxyCyclePause(TkmsShardPartition shardPartition, long durationMs);
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/ITkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/ITkmsMetricsTemplate.java
@@ -43,6 +43,8 @@ public interface ITkmsMetricsTemplate {
   Object registerEarliestMessageId(TkmsShardPartition shardPartition, Supplier<Number> supplier);
 
   void registerRowsInTableStats(TkmsShardPartition sp, long rowsInTableStats);
+  
+  void registerRowsInEngineIndependentTableStats(TkmsShardPartition sp, long rowsInTableStats);
 
   void registerRowsInIndexStats(TkmsShardPartition sp, long rowsInIndexStats);
 

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
@@ -33,36 +33,31 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class TkmsMetricsTemplate implements ITkmsMetricsTemplate {
 
-  public static final String PREFIX = "tw.tkms";
-
-  public static final String PREFIX_PROXY = PREFIX + ".proxy";
-  public static final String PREFIX_INTERFACE = PREFIX + ".interface";
-  public static final String PREFIX_DAO = PREFIX + ".dao";
-
-  public static final String METRIC_LIBRARY_INFO = "tw.library.info";
-  public static final String PROXY_POLL = PREFIX_PROXY + ".poll";
-  public static final String PROXY_CYCLE = PREFIX_PROXY + ".cycle";
-  public static final String PROXY_MESSAGE_SEND = PREFIX_PROXY + ".message.send";
-  public static final String PROXY_KAFKA_MESSAGES_SEND = PREFIX_PROXY + ".kafka.messages.send";
-  public static final String PROXY_MESSAGES_DELETION = PREFIX_PROXY + ".messages.delete";
-  public static final String INTERFACE_MESSAGE_REGISTERED = PREFIX_INTERFACE + ".message.registration";
-  public static final String DAO_MESSAGE_INSERT = PREFIX_DAO + ".message.insert";
-  public static final String DAO_MESSAGES_DELETION = PREFIX_DAO + ".messages.delete";
-  public static final String DAO_POLL_FIRST_RESULT = PREFIX_DAO + ".poll.first.result";
-  public static final String DAO_POLL_GET_CONNECTION = PREFIX_DAO + ".poll.get.connection";
-  public static final String DAO_POLL_ALL_RESULTS = PREFIX_DAO + ".poll.all.results";
-  public static final String DAO_POLL_ALL_RESULTS_COUNT = PREFIX_DAO + ".poll.all.results.count";
-  public static final String DAO_INVALID_GENERATED_KEYS_COUNT = PREFIX_DAO + ".insert.invalid.generated.keys.count";
-  public static final String DAO_ROWS_IN_TABLE_STATS = PREFIX_DAO + ".rows.in.table.stats";
-  public static final String DAO_ROWS_IN_INDEX_STATS = PREFIX_DAO + ".rows.in.index.stats";
-  public static final String DAO_APPROXIMATE_MESSAGES_COUNT = PREFIX_DAO + ".approximate.messages.count";
-  public static final String STORED_MESSAGE_PARSING = PREFIX + ".stored.message.parsing";
-  public static final String MESSAGE_INSERT_TO_ACK = PREFIX + ".message.insert.to.ack";
-  public static final String DAO_COMPRESSION_RATIO_ACHIEVED = PREFIX_DAO + ".serialization.compression.ratio";
-  public static final String DAO_ORIGINAL_SIZE_BYTES = PREFIX_DAO + ".serialization.original.size.bytes";
-  public static final String DAO_SERIALIZED_SIZE_BYTES = PREFIX_DAO + ".serialization.serialized.size.bytes";
-  public static final String DAO_EARLIEST_MESSAGE_ID = PREFIX_DAO + ".earliest.message.id";
-  public static final String DAO_EARLIEST_MESSAGE_ID_COMMIT = PROXY_POLL + ".earliest.message.id.poll";
+  public static final String METRIC_LIBRARY_INFO = "tw_library_info";
+  public static final String PROXY_POLL = "tw_tkms_proxy_poll";
+  public static final String PROXY_CYCLE = "tw_tkms_proxy_cycle";
+  public static final String PROXY_CYCLE_PAUSE = "tw_tkms_proxy_cycle_pause";
+  public static final String PROXY_MESSAGE_SEND = "tw_tkms_proxy_message_send";
+  public static final String PROXY_KAFKA_MESSAGES_SEND = "tw_tkms_proxy_kafka_messages_send";
+  public static final String PROXY_MESSAGES_DELETION = "tw_tkms_proxy_messages_delete";
+  public static final String INTERFACE_MESSAGE_REGISTERED = "tw_tkms_interface_message_registration";
+  public static final String DAO_MESSAGE_INSERT = "tw_tkms_dao_message_insert";
+  public static final String DAO_MESSAGES_DELETION = "tw_tkms_dao_messages_delete";
+  public static final String DAO_POLL_FIRST_RESULT = "tw_tkms_dao_poll_first_result";
+  public static final String DAO_POLL_GET_CONNECTION = "tw_tkms_dao_poll_get_connection";
+  public static final String DAO_POLL_ALL_RESULTS = "tw_tkms_dao_poll_all_results";
+  public static final String DAO_POLL_ALL_RESULTS_COUNT = "tw_tkms_dao_poll_all_results_count";
+  public static final String DAO_INVALID_GENERATED_KEYS_COUNT = "tw_tkms_dao_insert_invalid_generated_keys_count";
+  public static final String DAO_ROWS_IN_TABLE_STATS = "tw_tkms_dao_rows_in_table_stats";
+  public static final String DAO_ROWS_IN_INDEX_STATS = "tw_tkms_dao_rows_in_index_stats";
+  public static final String DAO_APPROXIMATE_MESSAGES_COUNT = "tw_tkms_dao_approximate_messages_count";
+  public static final String STORED_MESSAGE_PARSING = "tw_tkms_stored_message_parsing";
+  public static final String MESSAGE_INSERT_TO_ACK = "tw_tkms_message_insert_to_ack";
+  public static final String DAO_COMPRESSION_RATIO_ACHIEVED = "tw_tkms_dao_serialization_compression_ratio";
+  public static final String DAO_ORIGINAL_SIZE_BYTES = "tw_tkms_dao_serialization_original_size_bytes";
+  public static final String DAO_SERIALIZED_SIZE_BYTES = "tw_tkms_dao_serialization_serialized_size_bytes";
+  public static final String DAO_EARLIEST_MESSAGE_ID = "tw_tkms_dao_earliest_message_id";
+  public static final String DAO_EARLIEST_MESSAGE_ID_COMMIT = "tw_tkms_proxy_poll_earliest_message_id_poll";
 
   public static final Tag NA_SHARD_TAG = Tag.of("shard", "N/A");
   public static final Tag NA_PARTITION_TAG = Tag.of("partition", "N/A");
@@ -76,9 +71,10 @@ public class TkmsMetricsTemplate implements ITkmsMetricsTemplate {
   @PostConstruct
   public void init() {
     Map<String, double[]> slos = new HashMap<>();
-    double[] defaultSlos = new double[]{1, 5, 25, 125, 625, 3125};
+    double[] defaultSlos = new double[]{1, 5, 25, 125, 625, 3125, 15625};
     slos.put(PROXY_POLL, defaultSlos);
     slos.put(PROXY_CYCLE, defaultSlos);
+    slos.put(PROXY_CYCLE_PAUSE, defaultSlos);
     slos.put(DAO_POLL_FIRST_RESULT, defaultSlos);
     slos.put(DAO_POLL_ALL_RESULTS, defaultSlos);
     slos.put(DAO_POLL_GET_CONNECTION, defaultSlos);
@@ -86,8 +82,8 @@ public class TkmsMetricsTemplate implements ITkmsMetricsTemplate {
     slos.put(PROXY_MESSAGES_DELETION, defaultSlos);
     slos.put(STORED_MESSAGE_PARSING, defaultSlos);
     slos.put(DAO_POLL_ALL_RESULTS_COUNT, defaultSlos);
-    slos.put(MESSAGE_INSERT_TO_ACK, new double[]{1, 5, 25, 125, 625, 3125, 3125 * 5});
-    slos.put(DAO_COMPRESSION_RATIO_ACHIEVED, new double[]{0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.25, 2});
+    slos.put(MESSAGE_INSERT_TO_ACK, new double[]{1, 5, 25, 125, 625, 3125, 15625});
+    slos.put(DAO_COMPRESSION_RATIO_ACHIEVED, new double[]{0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.25, 2, 4});
 
     meterCache.getMeterRegistry().config().meterFilter(new MeterFilter() {
       @Override
@@ -220,6 +216,15 @@ public class TkmsMetricsTemplate implements ITkmsMetricsTemplate {
             pollResultTag(recordsCount > 0),
             shardTag(shardPartition)))
         .record(System.nanoTime() - startNanoTime, TimeUnit.NANOSECONDS);
+  }
+
+  @Override
+  public void recordProxyCyclePause(TkmsShardPartition shardPartition, long durationMs) {
+    meterCache
+        .timer(PROXY_CYCLE_PAUSE, TagsSet.of(
+            partitionTag(shardPartition),
+            shardTag(shardPartition)))
+        .record(durationMs, TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
@@ -331,7 +331,7 @@ public class TkmsMetricsTemplate implements ITkmsMetricsTemplate {
     Gauge.builder(DAO_ROWS_IN_ENGINE_INDEPENDENT_TABLE_STATS, () -> rowsInTableStats).tags(Tags.of(shardTag(sp), partitionTag(sp)))
         .register(meterCache.getMeterRegistry());
   }
-  
+
   @Override
   public void registerRowsInIndexStats(TkmsShardPartition sp, long rowsInIndexStats) {
     Gauge.builder(DAO_ROWS_IN_INDEX_STATS, () -> rowsInIndexStats).tags(Tags.of(shardTag(sp), partitionTag(sp)))

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
@@ -49,6 +49,7 @@ public class TkmsMetricsTemplate implements ITkmsMetricsTemplate {
   public static final String DAO_POLL_ALL_RESULTS_COUNT = "tw_tkms_dao_poll_all_results_count";
   public static final String DAO_INVALID_GENERATED_KEYS_COUNT = "tw_tkms_dao_insert_invalid_generated_keys_count";
   public static final String DAO_ROWS_IN_TABLE_STATS = "tw_tkms_dao_rows_in_table_stats";
+  public static final String DAO_ROWS_IN_ENGINE_INDEPENDENT_TABLE_STATS = "tw_tkms_dao_rows_in_engine_independent_table_stats";
   public static final String DAO_ROWS_IN_INDEX_STATS = "tw_tkms_dao_rows_in_index_stats";
   public static final String DAO_APPROXIMATE_MESSAGES_COUNT = "tw_tkms_dao_approximate_messages_count";
   public static final String STORED_MESSAGE_PARSING = "tw_tkms_stored_message_parsing";
@@ -325,6 +326,12 @@ public class TkmsMetricsTemplate implements ITkmsMetricsTemplate {
         .register(meterCache.getMeterRegistry());
   }
 
+  @Override
+  public void registerRowsInEngineIndependentTableStats(TkmsShardPartition sp, long rowsInTableStats) {
+    Gauge.builder(DAO_ROWS_IN_ENGINE_INDEPENDENT_TABLE_STATS, () -> rowsInTableStats).tags(Tags.of(shardTag(sp), partitionTag(sp)))
+        .register(meterCache.getMeterRegistry());
+  }
+  
   @Override
   public void registerRowsInIndexStats(TkmsShardPartition sp, long rowsInIndexStats) {
     Gauge.builder(DAO_ROWS_IN_INDEX_STATS, () -> rowsInIndexStats).tags(Tags.of(shardTag(sp), partitionTag(sp)))

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageTrackingIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageTrackingIntTest.java
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("earliest-message")
-public class EarliestMessageTrackingIntTest extends BaseIntTest {
+class EarliestMessageTrackingIntTest extends BaseIntTest {
 
   @Autowired
   private TransactionalKafkaMessageSender tkms;

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageTrackingIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageTrackingIntTest.java
@@ -10,7 +10,6 @@ import com.transferwise.kafka.tkms.api.TkmsShardPartition;
 import com.transferwise.kafka.tkms.config.TkmsProperties;
 import com.transferwise.kafka.tkms.dao.ITkmsDao;
 import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
-import com.transferwise.kafka.tkms.metrics.TkmsMetricsTemplate;
 import com.transferwise.kafka.tkms.test.BaseIntTest;
 import io.micrometer.core.instrument.Gauge;
 import java.nio.charset.StandardCharsets;
@@ -44,7 +43,7 @@ class EarliestMessageTrackingIntTest extends BaseIntTest {
     TkmsClockHolder.setClock(clock);
 
     Gauge earliestMessageIdGauge = await()
-        .until(() -> meterRegistry.find(TkmsMetricsTemplate.DAO_EARLIEST_MESSAGE_ID).tags("shard", "0", "partition", "0").gauge(), Objects::nonNull);
+        .until(() -> meterRegistry.find("tw_tkms_dao_earliest_message_id").tags("shard", "0", "partition", "0").gauge(), Objects::nonNull);
     assertThat(earliestMessageIdGauge.value()).isEqualTo(-1);
 
     clock.tick(Duration.ofSeconds(5));

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
@@ -125,6 +125,8 @@ abstract class EndToEndIntTest extends BaseIntTest {
       testMessagesListener.unregisterConsumer(messageCounter);
     }
 
+    await().until(this::areTablesEmpty);
+    // Provides good cause message
     assertThatTablesAreEmpty();
 
     assertThat(tkmsRegisteredMessagesCollector.getRegisteredMessages(testProperties.getTestTopic()).size()).isEqualTo(1);
@@ -493,6 +495,19 @@ abstract class EndToEndIntTest extends BaseIntTest {
   @SneakyThrows
   protected byte[] toJsonBytes(Object value) {
     return objectMapper.writeValueAsBytes(value);
+  }
+
+  protected boolean areTablesEmpty() {
+    for (int s = 0; s < tkmsProperties.getShardsCount(); s++) {
+      for (int p = 0; p < tkmsProperties.getPartitionsCount(s); p++) {
+        TkmsShardPartition sp = TkmsShardPartition.of(s, p);
+        int rowsCount = tkmsTestDao.getMessagesCount(sp);
+        if (rowsCount > 0) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   protected void assertThatTablesAreEmpty() {

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
@@ -567,15 +567,16 @@ abstract class EndToEndIntTest extends BaseIntTest {
 
       await().until(() -> receivedCount.get() > 0);
 
-      assertThat(
-          meterRegistry.find("tw_tkms_dao_serialization_serialized_size_bytes").tag("algorithm", algorithm.name().toLowerCase()).counter().count()
-              - startingSerializedSizeBytes).isEqualTo(expectedSerializedSize);
+      counter =
+          meterRegistry.find("tw_tkms_dao_serialization_serialized_size_bytes").tag("algorithm", algorithm.name().toLowerCase()).counter();
+      double serializedSizeBytes = counter == null ? 0 : counter.count();
+      assertThat(serializedSizeBytes - startingSerializedSizeBytes).isEqualTo(expectedSerializedSize);
 
       log.info("Messages received: " + receivedCount.get());
     } finally {
       testMessagesListener.unregisterConsumer(messageCounter);
     }
 
-    assertThat(tkmsRegisteredMessagesCollector.getRegisteredMessages(testProperties.getTestTopic()).size()).isEqualTo(1);
+    assertThat(tkmsRegisteredMessagesCollector.getRegisteredMessages(testProperties.getTestTopic())).hasSize(1);
   }
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
@@ -85,6 +85,7 @@ abstract class EndToEndIntTest extends BaseIntTest {
   }
 
   @Test
+  @SneakyThrows
   void testThatJsonStringMessageCanBeSentAndRetrieved() {
     var messagePart = "Hello World!";
     int messageMultiplier = 100;

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
@@ -49,7 +49,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 @BaseTestEnvironment
 @Slf4j
-class EndToEndIntTest extends BaseIntTest {
+abstract class EndToEndIntTest extends BaseIntTest {
 
   @Autowired
   private ObjectMapper objectMapper;
@@ -529,7 +529,7 @@ class EndToEndIntTest extends BaseIntTest {
 
   @ParameterizedTest
   @MethodSource("compressionInput")
-  void testMessageIsCompressed(CompressionAlgorithm algorithm, int expectedSerializedSize) throws Exception {
+  void testMessageIsCompressed(CompressionAlgorithm algorithm, int expectedSerializedSize) {
     var message = StringUtils.repeat("Hello World!", 100);
 
     AtomicInteger receivedCount = new AtomicInteger();

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/KafkaMetricsIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/KafkaMetricsIntTest.java
@@ -57,8 +57,7 @@ public class KafkaMetricsIntTest {
   }
 
   @Test
-  void testThatProducerMetricShowsSentMessage() throws Exception {
-
+  void testThatProducerMetricShowsSentMessage() {
     String message = "Hello World!";
 
     AtomicInteger receivedCount = new AtomicInteger();
@@ -87,6 +86,6 @@ public class KafkaMetricsIntTest {
     }
 
     assertThat(meterRegistry.find("kafka.producer.record.send.total").tags().functionCounter().count())
-        .as("Producer's metric shows one message sent.").isGreaterThan(0L);
+        .as("Producer's metric shows one message sent.").isPositive();
   }
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/ManualIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/ManualIntTest.java
@@ -1,0 +1,93 @@
+package com.transferwise.kafka.tkms;
+
+import static org.awaitility.Awaitility.await;
+
+import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHelper;
+import com.transferwise.kafka.tkms.api.ITransactionalKafkaMessageSender;
+import com.transferwise.kafka.tkms.api.TkmsMessage;
+import com.transferwise.kafka.tkms.test.BaseIntTest;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+
+@Slf4j
+@TestInstance(Lifecycle.PER_CLASS)
+@ActiveProfiles(profiles = {"test", "postgres"})
+@Disabled("Manually executed tests and utilities")
+class ManualIntTest extends BaseIntTest {
+
+  @Autowired
+  private TkmsStorageToKafkaProxy tkmsStorageToKafkaProxy;
+
+  @Autowired
+  private ITransactionsHelper transactionsHelper;
+
+  @Autowired
+  private ITransactionalKafkaMessageSender transactionalKafkaMessageSender;
+
+  @BeforeAll
+  public void setupClass() {
+    tkmsStorageToKafkaProxy.pause();
+    await().until(() -> tkmsStorageToKafkaProxy.isPaused());
+  }
+
+  @AfterEach
+  public void cleanupClass() {
+    tkmsRegisteredMessagesCollector.enable();
+  }
+
+  @Test
+  @SneakyThrows
+  void waitLongTime() {
+    tkmsStorageToKafkaProxy.resume();
+
+    Thread.sleep(6_000_000);
+  }
+
+  @Test
+  @SneakyThrows
+  void fillTkmsTable() {
+    tkmsRegisteredMessagesCollector.disable();
+
+    var content = "Hello World!";
+    var contentBytes = content.getBytes(StandardCharsets.UTF_8);
+
+    var batches = 100;
+    var batchSize = 100_000;
+    var startTimeMs = System.currentTimeMillis();
+
+    var executors = Executors.newFixedThreadPool(25);
+
+    for (int t = 0; t < batches; t++) {
+      int finalT = t;
+      executors.submit(() -> {
+        try {
+          transactionsHelper.withTransaction().run(() -> {
+            for (int i = 0; i < batchSize; i++) {
+              transactionalKafkaMessageSender.sendMessage(new TkmsMessage().setTopic("TestTopicPostgres").setKey("a").setValue(contentBytes));
+            }
+          });
+          log.info("Inserted batch #" + finalT);
+        } catch (Throwable throwable) {
+          log.error(throwable.getMessage(), throwable);
+        }
+      });
+    }
+
+    executors.shutdown();
+    executors.awaitTermination(10, TimeUnit.MINUTES);
+
+    log.info("Added {} records in {} ms.", batches * batchSize, System.currentTimeMillis() - startTimeMs);
+  }
+
+}

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/ManualIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/ManualIntTest.java
@@ -64,7 +64,7 @@ class ManualIntTest extends BaseIntTest {
 
     var batches = 100;
     var batchSize = 100_000;
-    var startTimeMs = System.currentTimeMillis();
+    final var startTimeMs = System.currentTimeMillis();
 
     var executors = Executors.newFixedThreadPool(25);
 

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MariaDbEndToEndIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MariaDbEndToEndIntTest.java
@@ -1,0 +1,5 @@
+package com.transferwise.kafka.tkms;
+
+public class MariaDbEndToEndIntTest extends EndToEndIntTest {
+
+}

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
@@ -2,6 +2,7 @@ package com.transferwise.kafka.tkms;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.transferwise.kafka.tkms.metrics.TkmsMetricsTemplate;
 import com.transferwise.kafka.tkms.test.BaseIntTest;
 import io.micrometer.core.instrument.Gauge;
 import org.awaitility.Awaitility;
@@ -12,12 +13,12 @@ class MonitoringIntTest extends BaseIntTest {
   @Test
   void testThatMonitoringMetricsArePresent() {
     Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find("tw.tkms.dao.approximate.messages.count").tags("shard", "0", "partition", "0").gauge();
+      Gauge gauge = meterRegistry.find(TkmsMetricsTemplate.DAO_APPROXIMATE_MESSAGES_COUNT).tags("shard", "0", "partition", "0").gauge();
       return gauge != null && gauge.value() >= 0;
     });
 
     Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find("tw.tkms.dao.approximate.messages.count").tags("shard", "1", "partition", "0").gauge();
+      Gauge gauge = meterRegistry.find(TkmsMetricsTemplate.DAO_APPROXIMATE_MESSAGES_COUNT).tags("shard", "1", "partition", "0").gauge();
       return gauge != null && gauge.value() >= 0;
     });
   }
@@ -25,12 +26,12 @@ class MonitoringIntTest extends BaseIntTest {
   @Test
   void testThatTableStatsMetricsArePresent() {
     Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find("tw.tkms.dao.rows.in.table.stats").tags("shard", "1", "partition", "0").gauge();
+      Gauge gauge = meterRegistry.find(TkmsMetricsTemplate.DAO_ROWS_IN_TABLE_STATS).tags("shard", "1", "partition", "0").gauge();
       return gauge != null && gauge.value() == 1_000_000;
     });
 
     Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find("tw.tkms.dao.rows.in.index.stats").tags("shard", "1", "partition", "0").gauge();
+      Gauge gauge = meterRegistry.find(TkmsMetricsTemplate.DAO_ROWS_IN_INDEX_STATS).tags("shard", "1", "partition", "0").gauge();
       return gauge != null && gauge.value() == 1_000_000;
     });
   }
@@ -38,11 +39,11 @@ class MonitoringIntTest extends BaseIntTest {
   @Test
   void earliestMessageIdIsRegistered() {
     Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find("tw.tkms.dao.earliest.message.id").tags("shard", "1", "partition", "0").gauge();
+      Gauge gauge = meterRegistry.find(TkmsMetricsTemplate.DAO_EARLIEST_MESSAGE_ID).tags("shard", "1", "partition", "0").gauge();
       return gauge != null;
     });
 
-    assertThat(meterRegistry.find("tw.tkms.dao.earliest.message.id").tags("shard", "0", "partition", "0").gauge())
+    assertThat(meterRegistry.find(TkmsMetricsTemplate.DAO_EARLIEST_MESSAGE_ID).tags("shard", "0", "partition", "0").gauge())
         .as("Earliest message id tracking is not enabled for shard 0.").isNull();
   }
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
@@ -2,7 +2,6 @@ package com.transferwise.kafka.tkms;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.transferwise.kafka.tkms.metrics.TkmsMetricsTemplate;
 import com.transferwise.kafka.tkms.test.BaseIntTest;
 import io.micrometer.core.instrument.Gauge;
 import org.awaitility.Awaitility;
@@ -13,12 +12,12 @@ class MonitoringIntTest extends BaseIntTest {
   @Test
   void testThatMonitoringMetricsArePresent() {
     Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find(TkmsMetricsTemplate.DAO_APPROXIMATE_MESSAGES_COUNT).tags("shard", "0", "partition", "0").gauge();
+      Gauge gauge = meterRegistry.find("tw_tkms_dao_approximate_messages_count").tags("shard", "0", "partition", "0").gauge();
       return gauge != null && gauge.value() >= 0;
     });
 
     Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find(TkmsMetricsTemplate.DAO_APPROXIMATE_MESSAGES_COUNT).tags("shard", "1", "partition", "0").gauge();
+      Gauge gauge = meterRegistry.find("tw_tkms_dao_approximate_messages_count").tags("shard", "1", "partition", "0").gauge();
       return gauge != null && gauge.value() >= 0;
     });
   }
@@ -26,12 +25,12 @@ class MonitoringIntTest extends BaseIntTest {
   @Test
   void testThatTableStatsMetricsArePresent() {
     Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find(TkmsMetricsTemplate.DAO_ROWS_IN_TABLE_STATS).tags("shard", "1", "partition", "0").gauge();
+      Gauge gauge = meterRegistry.find("tw_tkms_dao_rows_in_table_stats").tags("shard", "1", "partition", "0").gauge();
       return gauge != null && gauge.value() == 1_000_000;
     });
 
     Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find(TkmsMetricsTemplate.DAO_ROWS_IN_INDEX_STATS).tags("shard", "1", "partition", "0").gauge();
+      Gauge gauge = meterRegistry.find("tw_tkms_dao_rows_in_index_stats").tags("shard", "1", "partition", "0").gauge();
       return gauge != null && gauge.value() == 1_000_000;
     });
   }
@@ -39,11 +38,11 @@ class MonitoringIntTest extends BaseIntTest {
   @Test
   void earliestMessageIdIsRegistered() {
     Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find(TkmsMetricsTemplate.DAO_EARLIEST_MESSAGE_ID).tags("shard", "1", "partition", "0").gauge();
+      Gauge gauge = meterRegistry.find("tw_tkms_dao_earliest_message_id").tags("shard", "1", "partition", "0").gauge();
       return gauge != null;
     });
 
-    assertThat(meterRegistry.find(TkmsMetricsTemplate.DAO_EARLIEST_MESSAGE_ID).tags("shard", "0", "partition", "0").gauge())
+    assertThat(meterRegistry.find("tw_tkms_dao_earliest_message_id").tags("shard", "0", "partition", "0").gauge())
         .as("Earliest message id tracking is not enabled for shard 0.").isNull();
   }
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/PostgresEndToEndIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/PostgresEndToEndIntTest.java
@@ -22,7 +22,8 @@ public class PostgresEndToEndIntTest extends EndToEndIntTest {
 
   @ParameterizedTest
   @MethodSource("compressionInput")
-  public void testMessageIsCompressed(CompressionAlgorithm algorithm, int expectedSerializedSize) throws Exception {
+  @Override
+  public void testMessageIsCompressed(CompressionAlgorithm algorithm, int expectedSerializedSize) {
     super.testMessageIsCompressed(algorithm, expectedSerializedSize);
   }
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/PostgresMonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/PostgresMonitoringIntTest.java
@@ -1,5 +1,6 @@
 package com.transferwise.kafka.tkms;
 
+import com.transferwise.kafka.tkms.metrics.TkmsMetricsTemplate;
 import io.micrometer.core.instrument.Gauge;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,7 @@ public class PostgresMonitoringIntTest extends MonitoringIntTest {
   @Test
   void testThatTableStatsMetricsArePresent() {
     Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find("tw.tkms.dao.rows.in.table.stats").tags("shard", "1", "partition", "0").gauge();
+      Gauge gauge = meterRegistry.find(TkmsMetricsTemplate.DAO_ROWS_IN_TABLE_STATS).tags("shard", "1", "partition", "0").gauge();
       return gauge != null && gauge.value() == 1_000_000;
     });
   }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/PostgresMonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/PostgresMonitoringIntTest.java
@@ -1,6 +1,5 @@
 package com.transferwise.kafka.tkms;
 
-import com.transferwise.kafka.tkms.metrics.TkmsMetricsTemplate;
 import io.micrometer.core.instrument.Gauge;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -12,7 +11,7 @@ public class PostgresMonitoringIntTest extends MonitoringIntTest {
   @Test
   void testThatTableStatsMetricsArePresent() {
     Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find(TkmsMetricsTemplate.DAO_ROWS_IN_TABLE_STATS).tags("shard", "1", "partition", "0").gauge();
+      Gauge gauge = meterRegistry.find("tw_tkms_dao_rows_in_table_stats").tags("shard", "1", "partition", "0").gauge();
       return gauge != null && gauge.value() == 1_000_000;
     });
   }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/TkmsPaceMakerTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/TkmsPaceMakerTest.java
@@ -1,0 +1,27 @@
+package com.transferwise.kafka.tkms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.transferwise.kafka.tkms.api.TkmsShardPartition;
+import com.transferwise.kafka.tkms.config.TkmsProperties;
+import org.junit.jupiter.api.Test;
+
+class TkmsPaceMakerTest {
+
+  @Test
+  void correctPauseTimeIsCalculated() {
+    var paceMaker = new TkmsPaceMaker();
+    var properties = new TkmsProperties();
+    paceMaker.properties = properties;
+    TkmsShardPartition.init(properties);
+
+    var pause = paceMaker.getPollingPause(TkmsShardPartition.of(0, 0), 100, 0);
+    assertEquals(25, pause.toMillis());
+
+    pause = paceMaker.getPollingPause(TkmsShardPartition.of(0, 0), 100, 100);
+    assertEquals(0, pause.toMillis());
+
+    pause = paceMaker.getPollingPause(TkmsShardPartition.of(0, 0), 100, 50);
+    assertEquals(12, pause.toMillis());
+  }
+}

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSenderTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSenderTest.java
@@ -1,0 +1,26 @@
+package com.transferwise.kafka.tkms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TransactionalKafkaMessageSenderTest {
+
+  @Test
+  void deleteBatchSizesAreCorrectlyValidated() {
+    var sender = new TransactionalKafkaMessageSender();
+
+    sender.validateDeleteBatchSize(0, List.of(256, 4, 1), "test");
+
+    var e = assertThrows(IllegalStateException.class, () -> sender.validateDeleteBatchSize(0, List.of(1, 2, 1), "test"));
+    assertEquals("Invalid delete batch sizes provided for 'test', 1<=2.", e.getMessage());
+
+    e = assertThrows(IllegalStateException.class, () -> sender.validateDeleteBatchSize(1, List.of(-2, -3, 1), "test"));
+    assertEquals("Invalid delete batch sizes provided for 'test', -2<1.", e.getMessage());
+
+    e = assertThrows(IllegalStateException.class, () -> sender.validateDeleteBatchSize(1, List.of(4, 2), "test"));
+    assertEquals("Invalid delete batch sizes provided for 'test', last element has to be 1.", e.getMessage());
+  }
+}

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/PostgresTkmsDaoIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/PostgresTkmsDaoIntTest.java
@@ -1,5 +1,8 @@
 package com.transferwise.kafka.tkms.dao;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.transferwise.kafka.tkms.metrics.TkmsMetricsTemplate;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.test.context.ActiveProfiles;
@@ -7,5 +10,15 @@ import org.springframework.test.context.ActiveProfiles;
 @TestInstance(Lifecycle.PER_CLASS)
 @ActiveProfiles(profiles = {"test", "postgres"})
 class PostgresTkmsDaoIntTest extends TkmsDaoIntTest {
+
+  /*
+    Here we test if `delete-batch-sizes` custom configuration applies.
+   */
+  @Override
+  protected void assertDeleteBucketsCounts() {
+    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "51").counter().count()).isEqualTo(19);
+    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "11").counter().count()).isEqualTo(2);
+    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "5").counter().count()).isEqualTo(2);
+  }
 
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/PostgresTkmsDaoIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/PostgresTkmsDaoIntTest.java
@@ -2,7 +2,6 @@ package com.transferwise.kafka.tkms.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.transferwise.kafka.tkms.metrics.TkmsMetricsTemplate;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.test.context.ActiveProfiles;
@@ -16,9 +15,9 @@ class PostgresTkmsDaoIntTest extends TkmsDaoIntTest {
    */
   @Override
   protected void assertDeleteBucketsCounts() {
-    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "51").counter().count()).isEqualTo(19);
-    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "11").counter().count()).isEqualTo(2);
-    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "5").counter().count()).isEqualTo(2);
+    assertThat(meterRegistry.get("tw_tkms_dao_messages_delete").tags("batchSize", "51").counter().count()).isEqualTo(19);
+    assertThat(meterRegistry.get("tw_tkms_dao_messages_delete").tags("batchSize", "11").counter().count()).isEqualTo(2);
+    assertThat(meterRegistry.get("tw_tkms_dao_messages_delete").tags("batchSize", "5").counter().count()).isEqualTo(2);
   }
 
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/TkmsDaoIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/TkmsDaoIntTest.java
@@ -6,6 +6,7 @@ import static org.awaitility.Awaitility.await;
 import com.transferwise.kafka.tkms.TkmsStorageToKafkaProxy;
 import com.transferwise.kafka.tkms.api.TkmsMessage;
 import com.transferwise.kafka.tkms.api.TkmsShardPartition;
+import com.transferwise.kafka.tkms.metrics.TkmsMetricsTemplate;
 import com.transferwise.kafka.tkms.test.BaseIntTest;
 import com.transferwise.kafka.tkms.test.ProductionBug;
 import java.nio.charset.StandardCharsets;
@@ -57,12 +58,20 @@ class TkmsDaoIntTest extends BaseIntTest {
 
     tkmsDao.deleteMessages(TkmsShardPartition.of(0, 0), records);
 
-    assertThat(meterRegistry.get("tw.tkms.dao.messages.delete").tags("batchSize", "256").counter().count()).isEqualTo(3);
-    assertThat(meterRegistry.get("tw.tkms.dao.messages.delete").tags("batchSize", "64").counter().count()).isEqualTo(3);
-    assertThat(meterRegistry.get("tw.tkms.dao.messages.delete").tags("batchSize", "16").counter().count()).isEqualTo(2);
-    assertThat(meterRegistry.get("tw.tkms.dao.messages.delete").tags("batchSize", "4").counter().count()).isEqualTo(2);
-    assertThat(meterRegistry.get("tw.tkms.dao.messages.delete").tags("batchSize", "1").counter().count()).isEqualTo(1);
+    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).counters()
+        .stream().map(c -> c.count() * Integer.parseInt(c.getId().getTag("batchSize"))).reduce(0d, Double::sum))
+        .isEqualTo(1001);
+
+    assertDeleteBucketsCounts();
 
     assertThat(new JdbcTemplate(dataSource).queryForObject("select count(*) from outgoing_message_0_0", Integer.class)).isZero();
+  }
+
+  protected void assertDeleteBucketsCounts() {
+    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "256").counter().count()).isEqualTo(3);
+    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "64").counter().count()).isEqualTo(3);
+    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "16").counter().count()).isEqualTo(2);
+    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "4").counter().count()).isEqualTo(2);
+    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "1").counter().count()).isEqualTo(1);
   }
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/TkmsDaoIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/TkmsDaoIntTest.java
@@ -6,7 +6,6 @@ import static org.awaitility.Awaitility.await;
 import com.transferwise.kafka.tkms.TkmsStorageToKafkaProxy;
 import com.transferwise.kafka.tkms.api.TkmsMessage;
 import com.transferwise.kafka.tkms.api.TkmsShardPartition;
-import com.transferwise.kafka.tkms.metrics.TkmsMetricsTemplate;
 import com.transferwise.kafka.tkms.test.BaseIntTest;
 import com.transferwise.kafka.tkms.test.ProductionBug;
 import java.nio.charset.StandardCharsets;
@@ -58,7 +57,7 @@ class TkmsDaoIntTest extends BaseIntTest {
 
     tkmsDao.deleteMessages(TkmsShardPartition.of(0, 0), records);
 
-    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).counters()
+    assertThat(meterRegistry.get("tw_tkms_dao_messages_delete").counters()
         .stream().map(c -> c.count() * Integer.parseInt(c.getId().getTag("batchSize"))).reduce(0d, Double::sum))
         .isEqualTo(1001);
 
@@ -68,10 +67,10 @@ class TkmsDaoIntTest extends BaseIntTest {
   }
 
   protected void assertDeleteBucketsCounts() {
-    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "256").counter().count()).isEqualTo(3);
-    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "64").counter().count()).isEqualTo(3);
-    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "16").counter().count()).isEqualTo(2);
-    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "4").counter().count()).isEqualTo(2);
-    assertThat(meterRegistry.get(TkmsMetricsTemplate.DAO_MESSAGES_DELETION).tags("batchSize", "1").counter().count()).isEqualTo(1);
+    assertThat(meterRegistry.get("tw_tkms_dao_messages_delete").tags("batchSize", "256").counter().count()).isEqualTo(3);
+    assertThat(meterRegistry.get("tw_tkms_dao_messages_delete").tags("batchSize", "64").counter().count()).isEqualTo(3);
+    assertThat(meterRegistry.get("tw_tkms_dao_messages_delete").tags("batchSize", "16").counter().count()).isEqualTo(2);
+    assertThat(meterRegistry.get("tw_tkms_dao_messages_delete").tags("batchSize", "4").counter().count()).isEqualTo(2);
+    assertThat(meterRegistry.get("tw_tkms_dao_messages_delete").tags("batchSize", "1").counter().count()).isEqualTo(1);
   }
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/BaseIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/BaseIntTest.java
@@ -23,7 +23,7 @@ public class BaseIntTest {
 
   @Autowired
   protected IMeterCache meterCache;
-  
+
   @Autowired
   protected JdbcTemplate jdbcTemplate;
 

--- a/tw-tkms-starter/src/test/java/db/migration/earliestmessage/V2__Init.java
+++ b/tw-tkms-starter/src/test/java/db/migration/earliestmessage/V2__Init.java
@@ -18,7 +18,7 @@ public class V2__Init extends BaseJavaMigration {
           stmt.execute("CREATE TABLE " + tableName + " (\n"
               + "  id BIGSERIAL PRIMARY KEY,\n"
               + "  message BYTEA NOT NULL\n"
-              + ") WITH (autovacuum_analyze_threshold=1000000000, autovacuum_vacuum_threshold=100000, toast_tuple_target=8160) ");
+              + ") WITH (autovacuum_analyze_threshold=1000000000, toast_tuple_target=8160) ");
           log.info("Create table `" + tableName + "'.");
 
           stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN id SET (n_distinct=1000000);");

--- a/tw-tkms-starter/src/test/java/db/migration/earliestmessage/V2__Init.java
+++ b/tw-tkms-starter/src/test/java/db/migration/earliestmessage/V2__Init.java
@@ -24,8 +24,7 @@ public class V2__Init extends BaseJavaMigration {
           stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN id SET (n_distinct=1000000);");
           stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN message SET STORAGE EXTERNAL");
           stmt.executeUpdate("VACUUM FULL " + tableName);
-        }
-        finally{
+        } finally {
           stmt.close();
         }
       }

--- a/tw-tkms-starter/src/test/java/db/migration/mysql/V1__Init.java
+++ b/tw-tkms-starter/src/test/java/db/migration/mysql/V1__Init.java
@@ -23,9 +23,13 @@ public class V1__Init extends BaseJavaMigration {
           stmt.execute(
               "update mysql.innodb_index_stats set stat_value=1000000 where table_name = \"" + tableName + "\" and stat_description=\"id\";");
           stmt.execute("update mysql.innodb_table_stats set n_rows=1000000 where table_name like \"" + tableName + "\";");
-          stmt.execute("flush table " + tableName);
+          stmt.execute("insert into mysql.table_stats (db_name, table_name, cardinality) values(DATABASE(), \"" + tableName + "\", 1000000) on duplicate key update cardinality=1000000");
         }
       }
+    }
+
+    try (Statement stmt = context.getConnection().createStatement()) {
+      stmt.execute("flush tables");
     }
   }
 }

--- a/tw-tkms-starter/src/test/java/db/migration/mysql/V1__Init.java
+++ b/tw-tkms-starter/src/test/java/db/migration/mysql/V1__Init.java
@@ -23,7 +23,8 @@ public class V1__Init extends BaseJavaMigration {
           stmt.execute(
               "update mysql.innodb_index_stats set stat_value=1000000 where table_name = \"" + tableName + "\" and stat_description=\"id\";");
           stmt.execute("update mysql.innodb_table_stats set n_rows=1000000 where table_name like \"" + tableName + "\";");
-          stmt.execute("insert into mysql.table_stats (db_name, table_name, cardinality) values(DATABASE(), \"" + tableName + "\", 1000000) on duplicate key update cardinality=1000000");
+          stmt.execute("insert into mysql.table_stats (db_name, table_name, cardinality) values(DATABASE(), \"" + tableName
+              + "\", 1000000) on duplicate key update cardinality=1000000");
         }
       }
     }

--- a/tw-tkms-starter/src/test/java/db/migration/postgres/V1__Init.java
+++ b/tw-tkms-starter/src/test/java/db/migration/postgres/V1__Init.java
@@ -17,7 +17,7 @@ public class V1__Init extends BaseJavaMigration {
           stmt.execute("CREATE TABLE " + tableName + " (\n"
               + "  id BIGSERIAL PRIMARY KEY,\n"
               + "  message BYTEA NOT NULL\n"
-              + ") WITH (autovacuum_analyze_threshold=1000000000, autovacuum_vacuum_threshold=100000, toast_tuple_target=8160) ");
+              + ") WITH (autovacuum_analyze_threshold=1000000000, toast_tuple_target=8160) ");
           log.info("Create table `" + tableName + "'.");
 
           stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN id SET (n_distinct=1000000);");

--- a/tw-tkms-starter/src/test/resources/application.yml
+++ b/tw-tkms-starter/src/test/resources/application.yml
@@ -53,7 +53,8 @@ tw-graceful-shutdown:
   clients-reaction-time-ms: 1000
   strategies-check-interval-time-ms: 1000
 
-logging.level.org.apache.kafka.clients: WARN
+logging.level:
+  org.apache.kafka.clients: WARN
 
 tw-tkms-test:
   test-topic: TestTopic
@@ -69,9 +70,10 @@ spring:
   config:
     activate:
       on-profile: postgres
-
+  
 tw-tkms:
   database-dialect: POSTGRES
+  delete-batch-sizes: "51, 11, 5, 1"
 
 tw-tkms-test:
   test-topic: TestTopicPostgres

--- a/tw-tkms-starter/src/test/resources/application.yml
+++ b/tw-tkms-starter/src/test/resources/application.yml
@@ -48,6 +48,8 @@ tw-tkms:
     previous-version: 0.7.3
   monitoring:
     start-delay: 0s
+  internals:
+    assertion-level: 1
 
 tw-graceful-shutdown:
   clients-reaction-time-ms: 1000

--- a/tw-tkms-starter/src/test/resources/docker-compose.yml
+++ b/tw-tkms-starter/src/test/resources/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3.7'
 services:
   zookeeper:
     image: bitnami/zookeeper:3.5.5
-    hostname: zookeeper
     ports:
       - "2181"
     environment:
@@ -11,7 +10,6 @@ services:
       JVMFLAGS: -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -noverify -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
   kafka-zk:
     image: bitnami/zookeeper:3.4.14
-    hostname: kafka-zk
     ports:
       - "2181"
     environment:
@@ -21,7 +19,6 @@ services:
     image: wurstmeister/kafka:2.12-2.4.1
     depends_on:
       - kafka-zk
-    hostname: kafka
     ports:
       - "9092"
     environment:
@@ -45,8 +42,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   mariadb:
-    image: mariadb:10.3
-    hostname: mysql
+    image: mariadb:10.6
     ports:
       - "3306"
     environment:
@@ -56,9 +52,6 @@ services:
     --character-set-server=utf8mb4
     --collation-server=utf8mb4_unicode_ci --transaction-isolation=READ-COMMITTED --innodb_autoinc_lock_mode=2"
   postgres:
-    image: postgres:12
+    image: docker.tw.ee/postgres12
     ports:
       - "5432"
-    environment:
-      POSTGRES_PASSWORD: example-password-change-me
-    command: -c 'max_connections=200'

--- a/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/ITkmsRegisteredMessagesCollector.java
+++ b/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/ITkmsRegisteredMessagesCollector.java
@@ -10,6 +10,10 @@ public interface ITkmsRegisteredMessagesCollector {
 
   void clear();
 
+  void disable();
+
+  void enable();
+
   <T> List<T> getRegisteredJsonMessages(String topic, Class<T> clazz);
 
   List<RegisteredMessage> getRegisteredMessages(String topic);

--- a/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/TkmsRegisteredMessagesCollector.java
+++ b/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/TkmsRegisteredMessagesCollector.java
@@ -33,7 +33,7 @@ public class TkmsRegisteredMessagesCollector implements ITkmsRegisteredMessagesC
     if (!enabled) {
       return;
     }
-    
+
     if (messagesCount.get() >= tkmsTestProperties.getMaxCollectedMessages()) {
       throw new IllegalStateException(
           "Collected " + messagesCount.get() + " messages, while the limit is " + tkmsTestProperties.getMaxCollectedMessages());

--- a/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/TkmsRegisteredMessagesCollector.java
+++ b/tw-tkms-test-starter/src/main/java/com/transferwise/kafka/tkms/test/TkmsRegisteredMessagesCollector.java
@@ -26,8 +26,14 @@ public class TkmsRegisteredMessagesCollector implements ITkmsRegisteredMessagesC
 
   private AtomicInteger messagesCount = new AtomicInteger();
 
+  private boolean enabled = true;
+
   @Override
   public void messageRegistered(MessageRegisteredEvent event) {
+    if (!enabled) {
+      return;
+    }
+    
     if (messagesCount.get() >= tkmsTestProperties.getMaxCollectedMessages()) {
       throw new IllegalStateException(
           "Collected " + messagesCount.get() + " messages, while the limit is " + tkmsTestProperties.getMaxCollectedMessages());
@@ -43,6 +49,16 @@ public class TkmsRegisteredMessagesCollector implements ITkmsRegisteredMessagesC
   public void clear() {
     messages = new ConcurrentHashMap<>();
     messagesCount.set(0);
+  }
+
+  @Override
+  public void disable() {
+    enabled = false;
+  }
+
+  @Override
+  public void enable() {
+    enabled = true;
   }
 
   @Override


### PR DESCRIPTION
## Context

### Changed

#### Messages polling interval is now more dynamic.

We are pausing for `(pollingInterval * (batchSize - polledRecords) / batchSize)`, instead of just `pollingInteval`

E.g.

- when we poll a full batch, we will not wait at all and start the next cycle immediately.
- when we poll zero records, we will wait the full polling interval.
- when we get half-full batch, we will be waiting 50% from polling interval.

This would allow to reduce the amount of polling queries on Postgres databases for cases where message sending can be latency-tolerant.

For example a Postgres database can have many dead tuples in `Tkms` tables, due to HTAP workloads or autovacuum not being snappy enough to keep those
clean. Every poll query would need to traverse all the dead tuples, even if it would only return couple of records. See
more [here](docs/postgres_with_long_transactions.md).

Essentially it would allow to reduce Postgres database average CPU usage.

The default logic can be overridden by custom implementation of `ITkmsPaceMaker`.

`tw_tkms_proxy_cycle` timer does not include those pauses anymore.
`tw_tkms_proxy_cycle_pause` timer is added to specifically measure those pauses.

When upgrading to this version, it is recommended to take another fresh look of how long polling intervals you would like to use.

#### Index hints for Postgres queries.

It turned out, that the `n_distinct` trick we suggested in [setup](docs/setup.md), did not actually apply in all scenarios. We still had an incident
where delete queries started to do full sequential scans.

With this version, we will be relying on `pg_hint_plan` extension being available. Fortunately RDS is supporting it, meaning it is considered quite
stable.

Some initialization validation routines were added, checking if index hints actually do apply.

Removed the recommendation of setting `autovacuum_vacuum_threshold=100000` for tkms tables. Auto vacuum has its own, database side, `naptime` setting, 
to prevent it running in a tight loop. Earlier, that fear of those tight loops were the motivation to recommend it.

#### Configurable delete queries batch sizes.

Services can now configure delete queries batch sizes. This can be useful, when the database is still trying to do sequential scans let's say with
1024 parameters, but would not do it with 256.

This can be done via the `deleteBatchSizes` property.

#### Initialization validations

Added more initialization validations around database performance.

#### MariaDb fixed stats

The stats value recommendations for `stat_value` and `n_rows` was increased to 1,000,000, just in case.

### Docs

Added [Database Statistics Bias](docs/database_statistics_bias.md) to describe the main motivation for this change.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
