### PR TITLE
Removing read_uncommitted transactions around Postgres queries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.1] - 2023-02-06
+
+### Changed
+
+* Removed `READ_UNCOMMITTED` transactions around Postgres queries.
+  For some reason, it slows down the query planner dramatically.
+  Besides, the measured benefit from those we only got from MariaDb, when large amount of service are running on the same database server.
+
 ## [0.21.0] - 2023-01-31
 
 ### Changed
@@ -44,7 +52,7 @@ stable.
 
 Some initialization validation routines were added, checking if index hints actually do apply.
 
-Removed the recommendation of setting `autovacuum_vacuum_threshold=100000` for tkms tables. Auto vacuum has its own, database side, `naptime` setting, 
+Removed the recommendation of setting `autovacuum_vacuum_threshold=100000` for tkms tables. Auto vacuum has its own, database side, `naptime` setting,
 to prevent it running in a tight loop. Earlier, that fear of those tight loops were the motivation to recommend it.
 
 #### Configurable delete queries batch sizes.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.21.0
+version=0.21.1

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
@@ -8,7 +8,6 @@ import com.transferwise.kafka.tkms.config.TkmsProperties;
 import com.transferwise.kafka.tkms.config.TkmsProperties.NotificationLevel;
 import com.transferwise.kafka.tkms.config.TkmsProperties.NotificationType;
 import com.transferwise.kafka.tkms.metrics.ITkmsMetricsTemplate;
-import com.transferwise.kafka.tkms.metrics.MonitoringQuery;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -35,7 +34,6 @@ public class TkmsMariaDao extends TkmsDao {
 
   @Override
   @Transactional(rollbackFor = Exception.class, isolation = Isolation.READ_UNCOMMITTED)
-  @MonitoringQuery
   public long getApproximateMessagesCount(TkmsShardPartition sp) {
     List<Long> rows =
         jdbcTemplate.queryForList("select table_rows from information_schema.tables where table_schema=? and table_name = ?", Long.class,
@@ -45,71 +43,80 @@ public class TkmsMariaDao extends TkmsDao {
   }
 
   @Override
+  protected void validateSchema() {
+    transactionsHelper.withTransaction().withIsolation(Isolation.READ_UNCOMMITTED).run(() -> {
+      super.validateSchema();
+    });
+  }
+
+  @Override
   protected void validateEngineSpecifics() {
     if (!properties.isTableStatsValidationEnabled()) {
       return;
     }
 
-    for (int s = 0; s < properties.getShardsCount(); s++) {
+    transactionsHelper.withTransaction().withIsolation(Isolation.READ_UNCOMMITTED).run(() -> {
+      for (int s = 0; s < properties.getShardsCount(); s++) {
+        try {
+          for (int p = 0; p < properties.getPartitionsCount(s); p++) {
+            TkmsShardPartition sp = TkmsShardPartition.of(s, p);
+
+            long rowsInTableStats = getRowsFromTableStats(sp);
+            metricsTemplate.registerRowsInTableStats(sp, rowsInTableStats);
+
+            // Default log level should be at least error, because misconfiguration here can take down your database.
+            if (rowsInTableStats < 1_000_000) {
+              problemNotifier.notify(s, NotificationType.TABLE_STATS_NOT_FIXED, NotificationLevel.ERROR, () ->
+                  "Table for " + sp + " is not properly configured. Rows from table stats is " + rowsInTableStats + "."
+                      + "This can greatly affect performance of DELETE queries during peaks or database slowness. Please check the setup guide how "
+                      + "to fix table stats."
+              );
+            }
+
+            long rowsInIndexStats = getRowsFromIndexStats(sp);
+            metricsTemplate.registerRowsInIndexStats(sp, rowsInIndexStats);
+
+            if (rowsInIndexStats < 1_000_000) {
+              problemNotifier.notify(s, NotificationType.INDEX_STATS_NOT_FIXED, NotificationLevel.ERROR, () ->
+                  "Table for " + sp + " is not properly configured. Rows in index stats is " + rowsInIndexStats + "."
+                      + " This can greatly affect performance of DELETE queries during peaks or database slowness. Please check the setup guide how "
+                      + "to fix index stats."
+              );
+            }
+
+            long rowsInEngineIndependentTableStats = getRowsFromEngineIndependentTableStats(sp);
+            metricsTemplate.registerRowsInEngineIndependentTableStats(sp, rowsInTableStats);
+
+            if (rowsInEngineIndependentTableStats < 1_000_000) {
+              problemNotifier.notify(s, NotificationType.ENGINE_INDEPENDENT_TABLE_STATS_NOT_FIXED, NotificationLevel.ERROR, () ->
+                  "Table for " + sp + " is not properly configured. Rows in engine independent table stats is " + rowsInEngineIndependentTableStats
+                      + ". This can greatly affect performance of DELETE queries during peaks or database slowness. Please check the setup guide how "
+                      + "to fix table stats."
+              );
+            }
+          }
+        } catch (DataAccessException dae) {
+          // TODO: Currently our database do not 
+          problemNotifier.notify(s, NotificationType.TABLE_INDEX_STATS_CHECK_ERROR, NotificationLevel.WARN, () ->
+              "Validating table and index stats failed.", dae);
+        }
+      }
+
       try {
-        for (int p = 0; p < properties.getPartitionsCount(s); p++) {
-          TkmsShardPartition sp = TkmsShardPartition.of(s, p);
-
-          long rowsInTableStats = getRowsFromTableStats(sp);
-          metricsTemplate.registerRowsInTableStats(sp, rowsInTableStats);
-
-          // Default log level should be at least error, because misconfiguration here can take down your database.
-          if (rowsInTableStats < 1_000_000) {
-            problemNotifier.notify(s, NotificationType.TABLE_STATS_NOT_FIXED, NotificationLevel.ERROR, () ->
-                "Table for " + sp + " is not properly configured. Rows from table stats is " + rowsInTableStats + "."
-                    + "This can greatly affect performance of DELETE queries during peaks or database slowness. Please check the setup guide how "
-                    + "to fix table stats."
-            );
-          }
-
-          long rowsInIndexStats = getRowsFromIndexStats(sp);
-          metricsTemplate.registerRowsInIndexStats(sp, rowsInIndexStats);
-
-          if (rowsInIndexStats < 1_000_000) {
-            problemNotifier.notify(s, NotificationType.INDEX_STATS_NOT_FIXED, NotificationLevel.ERROR, () ->
-                "Table for " + sp + " is not properly configured. Rows in index stats is " + rowsInIndexStats + "."
-                    + " This can greatly affect performance of DELETE queries during peaks or database slowness. Please check the setup guide how "
-                    + "to fix index stats."
-            );
-          }
-
-          long rowsInEngineIndependentTableStats = getRowsFromEngineIndependentTableStats(sp);
-          metricsTemplate.registerRowsInEngineIndependentTableStats(sp, rowsInTableStats);
-
-          if (rowsInEngineIndependentTableStats < 1_000_000) {
-            problemNotifier.notify(s, NotificationType.ENGINE_INDEPENDENT_TABLE_STATS_NOT_FIXED, NotificationLevel.ERROR, () ->
-                "Table for " + sp + " is not properly configured. Rows in engine independent table stats is " + rowsInEngineIndependentTableStats
-                    + ". This can greatly affect performance of DELETE queries during peaks or database slowness. Please check the setup guide how "
-                    + "to fix table stats."
-            );
-          }
+        var userStatTables = getUserStatTablesVariable();
+        if (!userStatTables.equalsIgnoreCase("preferably") && !userStatTables.equalsIgnoreCase("preferably_for_queries")) {
+          problemNotifier.notify(null, NotificationType.ENGINE_INDEPENDENT_STATS_NOT_ENABLED, NotificationLevel.WARN, () ->
+              "Checking if engine independent statics are available and preferred, failed.");
         }
       } catch (DataAccessException dae) {
-        // TODO: Currently our database do not 
-        problemNotifier.notify(s, NotificationType.TABLE_INDEX_STATS_CHECK_ERROR, NotificationLevel.WARN, () ->
-            "Validating table and index stats failed.", dae);
+        problemNotifier.notify(null, NotificationType.TABLE_INDEX_STATS_CHECK_ERROR, NotificationLevel.ERROR, () ->
+            "Checking if engine independent stats are enabled, failed.", dae);
       }
-    }
-
-    try {
-      var userStatTables = getUserStatTablesVariable();
-      if (!userStatTables.equalsIgnoreCase("preferably") && !userStatTables.equalsIgnoreCase("preferably_for_queries")) {
-        problemNotifier.notify(null, NotificationType.ENGINE_INDEPENDENT_STATS_NOT_ENABLED, NotificationLevel.WARN, () ->
-            "Checking if engine independent statics are available and preferred, failed.");
-      }
-    } catch (DataAccessException dae) {
-      problemNotifier.notify(null, NotificationType.TABLE_INDEX_STATS_CHECK_ERROR, NotificationLevel.ERROR, () ->
-          "Checking if engine independent stats are enabled, failed.", dae);
-    }
+    });
   }
 
   private long getRowsFromTableStats(TkmsShardPartition shardPartition) {
-    return transactionsHelper.withTransaction().asNew().withIsolation(Isolation.READ_UNCOMMITTED).call(() -> {
+    return transactionsHelper.withTransaction().withIsolation(Isolation.READ_UNCOMMITTED).call(() -> {
       List<Long> stats = jdbcTemplate.queryForList("select n_rows from mysql.innodb_table_stats where database_name=? and table_name=?", Long.class,
           getSchemaName(shardPartition), getTableNameWithoutSchema(shardPartition));
 
@@ -121,7 +128,7 @@ public class TkmsMariaDao extends TkmsDao {
   }
 
   private long getRowsFromEngineIndependentTableStats(TkmsShardPartition shardPartition) {
-    return transactionsHelper.withTransaction().asNew().withIsolation(Isolation.READ_UNCOMMITTED).call(() -> {
+    return transactionsHelper.withTransaction().withIsolation(Isolation.READ_UNCOMMITTED).call(() -> {
       List<Long> stats = jdbcTemplate.queryForList("select cardinality from mysql.table_stats where db_name=? and table_name=?", Long.class,
           getSchemaName(shardPartition), getTableNameWithoutSchema(shardPartition));
 
@@ -133,12 +140,12 @@ public class TkmsMariaDao extends TkmsDao {
   }
 
   private String getUserStatTablesVariable() {
-    return transactionsHelper.withTransaction().asNew().withIsolation(Isolation.READ_UNCOMMITTED)
+    return transactionsHelper.withTransaction().withIsolation(Isolation.READ_UNCOMMITTED)
         .call(() -> jdbcTemplate.queryForObject("select @@use_stat_tables", String.class));
   }
 
   private long getRowsFromIndexStats(TkmsShardPartition shardPartition) {
-    return transactionsHelper.withTransaction().asNew().withIsolation(Isolation.READ_UNCOMMITTED).call(() -> {
+    return transactionsHelper.withTransaction().withIsolation(Isolation.READ_UNCOMMITTED).call(() -> {
       List<Long> stats = jdbcTemplate.queryForList(
           "select stat_value from mysql.innodb_index_stats where database_name=? and stat_description='id' and " + "table_name=?", Long.class,
           getSchemaName(shardPartition), getTableNameWithoutSchema(shardPartition));
@@ -163,7 +170,7 @@ public class TkmsMariaDao extends TkmsDao {
       table = defaultTable;
     }
 
-    return transactionsHelper.withTransaction().asNew().withIsolation(Isolation.READ_UNCOMMITTED).call(
+    return transactionsHelper.withTransaction().withIsolation(Isolation.READ_UNCOMMITTED).call(
         () -> !jdbcTemplate.queryForList("SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", Boolean.class,
             schema, table).isEmpty()
     );
@@ -178,6 +185,12 @@ public class TkmsMariaDao extends TkmsDao {
   protected String getEarliestMessageIdSql(TkmsShardPartition shardPartition) {
     var earliestVisibleMessages = properties.getEarliestVisibleMessages(shardPartition.getShard());
     return "select message_id from " + earliestVisibleMessages.getTableName() + " use index(PRIMARY) where shard=? and part=?";
+  }
+
+  @Override
+  public boolean hasMessagesBeforeId(TkmsShardPartition shardPartition, Long messageId) {
+    return transactionsHelper.withTransaction().withIsolation(Isolation.READ_UNCOMMITTED)
+        .call(() -> super.hasMessagesBeforeId(shardPartition, messageId));
   }
 
   @Override


### PR DESCRIPTION
## Context

### Changed

* Removed `READ_UNCOMMITTED` transactions around Postgres queries.
  For some reason, it slows down the query planner dramatically.
  Besides, the measured benefit from those we only got from MariaDb, when large amount of service are running on the same database server.

## Checklist
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
