### PR TITLE
[APPENG-416] Convert existing documentation into TechDocs format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,53 +2,15 @@
 
 ![Apache 2](https://img.shields.io/hexpm/l/plug.svg)
 ![Java 11](https://img.shields.io/badge/Java-11-blue.svg)
-![Maven Central](https://badgen.net/maven/v/maven-central/com.transferwise.kafka/tw-tkms-starter)
-[![Owners](https://img.shields.io/badge/team-AppEng-blueviolet.svg?logo=wise)](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/2520812116/Application+Engineering+Team) [![Slack](https://img.shields.io/badge/slack-tw--task--exec-blue.svg?logo=slack)](https://wise.slack.com/archives/C7P9L0B6Z)
+![Maven Central](https://img.shields.io/maven-central/v/com.transferwise.kafka/tw-tkms-starter?logo=ApacheMaven)
+[![Owners](https://img.shields.io/badge/team-AppEng-blueviolet.svg?logo=wise)](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/2520812116/Application+Engineering+Team)
+[![Slack](https://img.shields.io/badge/slack-tw--task--exec-blue.svg?logo=slack)](https://wise.slack.com/archives/C7P9L0B6Z)
 > Use the `@application-engineering-on-call` handle on Slack for help.
 ---
+> A library for sending Kafka messages according to the Transactional Outbox Pattern.
 
-A library for sending Kafka messages according to the [Transactional Outbox Pattern](https://microservices.io/patterns/data/transactional-outbox.html)
-
-* Guarantees messages ordering
-    * Messages with the same key/partition added in a transaction, will end up in a target Kafka partition in the order they were added.
-    * Messages with the same key/partition added in two consecutive transactions will end up in the correct Kafka partition in the order they were
-      added.
-    * There are no illusionary global ordering guarantees, the same as for Kafka itself.
-* Efficient and high performance
-* Supports both JSON and binary messages
-* Supports all Kafka Client features, like headers and forcing messages into specific partitions
-* Replaces [tw-tasks-kafka-publisher](https://github.com/transferwise/tw-tasks-executor/tree/master/tw-tasks-kafka-publisher)
-* At least once delivery
-* Supports both Postgres and MariaDb.
-
-Do not use this library
-
-* If you do not need atomic transactions around your business data and Kafka messages.
-    * For example:
-        * You are just converting incoming Kafka messages into messages for another topic.
-        * The only thing your logic does is send out Kafka messages and it does not change the main database.
-
-You would probably want to start by going over the [main concepts](docs/concepts.md).
-
-First, you need to [set it up](docs/setup.md).
-
-Then you can [start using it](docs/usage.md).
-
-Of course, the library can be used in your service's [integration tests](docs/testing.md)
-
-[Performance considerations](docs/performance.md) can be quite useful to check out.
-
-If there's any [trouble](docs/troubleshooting.md), you will be prepared.
-
-The library also provides [observability](docs/observability.md).
-
-At Wise we are "enhancing and fixing a flying airplane", so make sure you will not cause any incidents while
-[migrating](docs/migration.md) to the library.
-
-Feel free to [contribute](docs/contributing.md) and come and chat in the #tw-task-exec Slack channel.
-
-If you are a Postgres database user, then it is utmost important to be familiar
-with [Postgres OLAP/HTAP workloads issues](docs/postgres_with_long_transactions.md)
+## 📚 Documentation
+Documentation for the library is available [here](docs/index.md).
 
 ## License
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,3 +17,6 @@ One of them with `node2` Spring profile.
 5. Check if test finishes correctly as fast as it did in master.
 
 Repeat the tests for Postgres, by starting `demoapp` with `postgres` Spring profile.
+
+## Raising a PR
+Before raising a PR, please ensure that you have updated the [project's version](https://github.com/transferwise/tw-tkms/blob/master/gradle.properties) following [semantic versioning](https://semver.org/spec/v2.0.0.html), and have updated the [CHANGELOG](https://github.com/transferwise/tw-tkms/blob/master/CHANGELOG.md) accordingly.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,60 @@
+# TransferWise Transactional Kafka Message Sender Documentation
+> A library for sending Kafka messages according to the [Transactional Outbox Pattern](https://microservices.io/patterns/data/transactional-outbox.html).
+
+## Table of Contents
+* [About](#about)
+* [Main Concepts](concepts.md)
+* [Setting the Library Up](setup.md)
+* [Using the Library](usage.md)
+* [Implementing Integration Tests](testing.md)
+* [Performance Considerations](performance.md)
+* [Troubleshooting](troubleshooting.md)
+* [Observability](observability.md)
+* [Metrics Provided by the Library](metrics.md)
+* [Migrating to the Library](migration.md)
+* [Postgres OLAP/HTAP Workload Issues](postgres_with_long_transactions.md)
+* [Database Statistics Bias](database_statistics_bias.md)
+* [Contribution Guide](contributing.md)
+
+## About
+The library:
+* Guarantees messages ordering
+    * Messages with the same key/partition added in a transaction, will end up in a target Kafka partition in the order they were added.
+    * Messages with the same key/partition added in two consecutive transactions will end up in the correct Kafka partition in the order they were
+      added.
+    * There are no illusionary global ordering guarantees, the same as for Kafka itself.
+* Efficient and high performance
+* Supports both JSON and binary messages
+* Supports all Kafka Client features, like headers and forcing messages into specific partitions
+* Replaces [tw-tasks-kafka-publisher](https://github.com/transferwise/tw-tasks-executor/tree/master/tw-tasks-kafka-publisher)
+* At least once delivery
+* Supports both Postgres and MariaDb.
+
+Do not use this library
+
+* If you do not need atomic transactions around your business data and Kafka messages.
+    * For example:
+        * You are just converting incoming Kafka messages into messages for another topic.
+        * The only thing your logic does is send out Kafka messages and, it does not change the main database.
+
+You would probably want to start by going over the [main concepts](concepts.md).
+
+First, you need to [set it up](setup.md).
+
+Then you can [start using it](usage.md).
+
+Of course, the library can be used in your service's [integration tests](testing.md)
+
+[Performance considerations](performance.md) can be quite useful to check out.
+
+If there's any [trouble](troubleshooting.md), you will be prepared.
+
+The library also provides [observability](observability.md).
+
+At Wise, we are "enhancing and fixing a flying airplane", so make sure you will not cause any incidents while
+[migrating](migration.md) to the library.
+
+Feel free to [contribute](contributing.md) and come and chat in the #tw-task-exec Slack channel.
+
+If you are a Postgres database user, then it is utmost important to be familiar
+with [Postgres OLAP/HTAP workloads issues](postgres_with_long_transactions.md)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -16,5 +16,5 @@ For example.
 
 Important here is to not remove the tw-tasks-kafka-publisher with the same release with what you are migrating the last topic.
 
-Instead you need to do one release, allowing all messages already sent by tw-tasks get fully processed. And then after 2 days,
+Instead, you need to do one release, allowing all messages already sent by tw-tasks get fully processed. And then after 2 days,
 when there is absolutely sure no rollback will be needed, you can finally remove the `tw-tasks-kafka-publisher` dependency and configuration.

--- a/docs/postgres_with_long_transactions.md
+++ b/docs/postgres_with_long_transactions.md
@@ -1,8 +1,8 @@
-# Postgres with long running transactions
+# Postgres with long-running transactions
 
 ## The problem
 
-When `tw-tkms` is running on a Postgres database with long running transactions, the following happens.
+When `tw-tkms` is running on a Postgres database with long-running transactions, the following happens.
 
 - Database starts using more and more CPU.
 - `tw-tkms` throughput plummets.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -2,9 +2,21 @@
 
 We are assuming you are using Spring Boot, at least version 2.5.
 
-```groovy
-implementation 'com.transferwise.kafka:tw-tkms-starter'
+First ensure that you have the `mavenCentral` repository available in your Gradle buildscript:
+```yaml
+repositories {
+  mavenCentral()
+}
 ```
+
+Then, declare the tw-twks library as a dependency in your Gradle buildscript: 
+
+```groovy
+dependencies {
+    implementation 'com.transferwise.kafka:tw-tkms-starter:<VERSION>'
+}
+```
+> Replace `<VERSION>` with the version of the library you wish to use.
 
 Configuration can be tweaked according to `com.transferwise.kafka.tkms.config.TkmsProperties`. Usually there is no need to change the defaults.
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,0 +1,17 @@
+site_name: tw-tkms Documentation
+repo_url: https://github.com/transferwise/tw-tkms
+edit_uri: blob/master/docs/
+nav:
+  - Overview: index.md
+  - Concepts: concepts.md
+  - Setup: setup.md
+  - Usage: usage.md
+  - Migrating: migration.md
+  - Performance Considerations: performance.md
+  - Troubleshooting: troubleshooting.md
+  - Integration Tests: testing.md
+  - Observability: observability.md
+  - Metrics: metrics.md
+  - Postgres OLAP/HTAP Workloads Issues: postgres_with_long_transactions.md
+  - Database Statistics Bias: database_statistics_bias.md
+  - Contribution Guide: contributing.md


### PR DESCRIPTION
## Context

Converting the existing documentation into the TechDocs format and also fixing some spelling errors, contribution guide and just generally polishing the documentation.

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
