### PR TITLE
Table and index statistics fixation overhaul.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.4] - 2023-03-03
+
+### Changed
+
+* When engine independent stats are enabled in MariaDb, we only check if statistics are fixated in those.
+
+* Consequently, in documentation we only ask to fixate engine independent statistics.
+
+### Removed
+
+* All around recommending to fixate `n_distinct` table parameter.
+  It actually did not seem to work and the correct way is still to rely on `pg_hint_plan` extension.
+
 ## [0.21.3] - 2023-02-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-* All around recommending to fixate `n_distinct` table parameter.
+* All around recommending to fixate `n_distinct` table parameter for Postgres.
   It actually did not seem to work and the correct way is still to rely on `pg_hint_plan` extension.
 
 ## [0.21.3] - 2023-02-21

--- a/demoapp/src/main/java/db/migration/postgres/V1__Init.java
+++ b/demoapp/src/main/java/db/migration/postgres/V1__Init.java
@@ -20,7 +20,6 @@ public class V1__Init extends BaseJavaMigration {
               + ") WITH (autovacuum_analyze_threshold=1000000000, toast_tuple_target=8160)");
           log.info("Create table `" + tableName + "'.");
 
-          stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN id SET (n_distinct=1000000);");
           stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN message SET STORAGE EXTERNAL");
           stmt.executeUpdate("VACUUM FULL " + tableName);
         }

--- a/docs/database_statistics_bias.md
+++ b/docs/database_statistics_bias.md
@@ -58,22 +58,14 @@ Unfortunately MariaDb does not support index hints on `DELETE` queries. MySql do
 
 > Applies only for MariaDb. 
 > Does not apply to Postgres, where we will rely on `pg_hint_plan` plugin.
-> Does not apply to MySql, for which we have index hints in all queries, including for DELETE statements.
+> Does not apply to MySql, for which we have index hints in all queries, including in DELETE statements.
 
 [setup guide](setup.md) will show you how.
 
-In the case of MariaDb, as described above, it is very important to avoid running random ANALYZE on those tables, as
+In the case of MariaDb, as described above, it is very important to avoid running random `ANALYZE TABLE PERSISTENT FOR ALL`  on those tables, as
 it will highly likely be run when the table is empty and thus overwriting all our fixed statistics to indicate tables with large amount of records.
 
 If this happens, it is important to fix the statistics back into place.
-
-<!-- @formatter:off -->
-```mariadb
-update mysql.innodb_index_stats set stat_value=1000000 where table_name like "outgoing_message_%" and stat_description="id";
-update mysql.innodb_table_stats set n_rows=1000000 where table_name like "outgoing_message_%";
-flush table outgoing_message_*_*;
-```
-<!-- @formatter:on -->
 
 ## Manual intervention
 
@@ -112,7 +104,7 @@ So, if we would create lots of records into those tables, with negative ids, and
 > However messages on those records can be empty, so we would only keep 8 byte integers in those. 
 > If we put 1 million records there, they may take "only" couple of tens of megabytes.
 
-This can be useful for using `tw-tkms`
+This can be useful when using `tw-tkms`
 * on other databases
 * on Postgres without `pg_hint_plan` extension
 * on MariaDb where you have some general automation running frequent ANALYZE statements on tables. 

--- a/docs/database_statistics_bias.md
+++ b/docs/database_statistics_bias.md
@@ -49,16 +49,20 @@ Index hints are built into MariaDb and MySql; and for Postgres there is the [pg_
 
 Unfortunately MariaDb does not support index hints on `DELETE` queries. MySql does.
 
-> So for MariaDb we still have a big risk - randomly ran `ANALYZE` statements.
+> So for MariaDb we still have a big risk - randomly executed `ANALYZE` statements.
 
 > Even when we fix the statistic in place, telling database that there are large amount of records,
 > a DBA accidentally running manual `ANALYZE`, at a time when the table is empty, will override those and thus negate the desired effect.
 
 ### Fixing statistics in place.
 
+> Applies only for MariaDb. 
+> Does not apply to Postgres, where we will rely on `pg_hint_plan` plugin.
+> Does not apply to MySql, for which we have index hints in all queries, including for DELETE statements.
+
 [setup guide](setup.md) will show you how.
 
-In the case of MariaDb/MySql, as described above, it is very important to avoid running random ANALYZE on those tables, as
+In the case of MariaDb, as described above, it is very important to avoid running random ANALYZE on those tables, as
 it will highly likely be run when the table is empty and thus overwriting all our fixed statistics to indicate tables with large amount of records.
 
 If this happens, it is important to fix the statistics back into place.
@@ -107,3 +111,8 @@ So, if we would create lots of records into those tables, with negative ids, and
 > The downside here is that we may "waste" disk space, and it may look a bit messy.
 > However messages on those records can be empty, so we would only keep 8 byte integers in those. 
 > If we put 1 million records there, they may take "only" couple of tens of megabytes.
+
+This can be useful for using `tw-tkms`
+* on other databases
+* on Postgres without `pg_hint_plan` extension
+* on MariaDb where you have some general automation running frequent ANALYZE statements on tables. 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -74,13 +74,15 @@ set [innodb_autoinc_lock_mode](https://mariadb.com/docs/reference/es/system-vari
 
 If we can not rely on engine independent statistics, we can still rely on innodb engine statistics as following.
 
+<!-- @formatter:off -->
 ```mariadb
 -- Set engine stats.
 update mysql.innodb_index_stats set stat_value=1000000 where table_name = "outgoing_message_0_0" and stat_description="id";
 update mysql.innodb_table_stats set n_rows=1000000 where table_name like "outgoing_message_0_0";
 ```
+<!-- @formatter:on -->
 
-But notice, that anyone running `ANALYZE` on those tables, will rewrite those entries, and you would have to replay the statements above. 
+But notice, that anyone running `ANALYZE` on those tables, will rewrite statistics entries, and you would have to replay the statements above.
 
 ## Postgres
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.21.3
+version=0.21.4

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageTrackingIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageTrackingIntTest.java
@@ -77,7 +77,7 @@ class EarliestMessageTrackingIntTest extends BaseIntTest {
 
   protected void sendMessageAndWaitForArrival(int cnt) {
     transactionsHelper.withTransaction().run(() ->
-        tkms.sendMessage(new TkmsMessage().setTopic(testTopic).setValue("Hello World!".getBytes(StandardCharsets.UTF_8)))
+        tkms.sendMessage(new TkmsMessage().setTopic(testTopic).setValue("Hello Kristo!".getBytes(StandardCharsets.UTF_8)))
     );
 
     await().until(() -> tkmsSentMessagesCollector.getSentMessages(testTopic).size() == cnt);

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
@@ -528,12 +528,12 @@ abstract class EndToEndIntTest extends BaseIntTest {
 
   private static Stream<Arguments> compressionInput() {
     return Stream.of(
-        Arguments.of(CompressionAlgorithm.GZIP, 104),
-        Arguments.of(CompressionAlgorithm.NONE, 1263),
-        Arguments.of(CompressionAlgorithm.LZ4, 127),
-        Arguments.of(CompressionAlgorithm.SNAPPY, 157),
-        Arguments.of(CompressionAlgorithm.SNAPPY_FRAMED, 155),
-        Arguments.of(CompressionAlgorithm.ZSTD, 93)
+        Arguments.of(CompressionAlgorithm.GZIP, 103),
+        Arguments.of(CompressionAlgorithm.NONE, 1163),
+        Arguments.of(CompressionAlgorithm.LZ4, 126),
+        Arguments.of(CompressionAlgorithm.SNAPPY, 158),
+        Arguments.of(CompressionAlgorithm.SNAPPY_FRAMED, 156),
+        Arguments.of(CompressionAlgorithm.ZSTD, 92)
     );
   }
 

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
@@ -242,7 +242,7 @@ abstract class EndToEndIntTest extends BaseIntTest {
 
   @Test
   void testThatMessagesWithSamePartitionEndUpInOnePartition() {
-    String message = "Hello World!";
+    String message = "Hello Fabio!";
     int partition = 3;
     int n = 20;
     ConcurrentHashMap<Integer, AtomicInteger> partitionsMap = new ConcurrentHashMap<>();
@@ -279,7 +279,7 @@ abstract class EndToEndIntTest extends BaseIntTest {
 
   @Test
   void testThatMessagesOrderForAnEntityIsPreserved() throws Exception {
-    String message = "Hello World!";
+    String message = "Hello Jarvis!";
     int entitiesCount = 100;
     int entityEventsCount = 100;
     int messagesCount = entitiesCount * entityEventsCount;
@@ -355,7 +355,7 @@ abstract class EndToEndIntTest extends BaseIntTest {
 
   @Test
   void sendingMultipleMessagesWorks() {
-    byte[] value = "{\"message\" : \"Hello World!\"}".getBytes(StandardCharsets.UTF_8);
+    byte[] value = "{\"message\" : \"Hello Nerius!\"}".getBytes(StandardCharsets.UTF_8);
 
     AtomicInteger receivedCount = new AtomicInteger();
     Consumer<ConsumerRecord<String, String>> messageCounter =
@@ -455,7 +455,7 @@ abstract class EndToEndIntTest extends BaseIntTest {
    */
   @Test
   void testThatTemporaryDeleteFailureDoesNotLeaveTrashBehind() {
-    String message = "Hello World!";
+    String message = "Hello Peeter!";
     int messagesCount = 1000;
 
     var receivedCount = new AtomicInteger();
@@ -540,7 +540,7 @@ abstract class EndToEndIntTest extends BaseIntTest {
   @ParameterizedTest
   @MethodSource("compressionInput")
   void testMessageIsCompressed(CompressionAlgorithm algorithm, int expectedSerializedSize) {
-    var message = StringUtils.repeat("Hello World!", 100);
+    var message = StringUtils.repeat("Hello Aivo!", 100);
 
     AtomicInteger receivedCount = new AtomicInteger();
     Consumer<ConsumerRecord<String, String>> messageCounter = cr -> ExceptionUtils.doUnchecked(() -> {

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/KafkaMetricsIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/KafkaMetricsIntTest.java
@@ -58,7 +58,7 @@ public class KafkaMetricsIntTest {
 
   @Test
   void testThatProducerMetricShowsSentMessage() {
-    String message = "Hello World!";
+    String message = "Hello Toomas!";
 
     AtomicInteger receivedCount = new AtomicInteger();
     Consumer<ConsumerRecord<String, String>> messageCounter = cr -> ExceptionUtils.doUnchecked(() -> {

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/ManualIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/ManualIntTest.java
@@ -59,7 +59,7 @@ class ManualIntTest extends BaseIntTest {
   void fillTkmsTable() {
     tkmsRegisteredMessagesCollector.disable();
 
-    var content = "Hello World!";
+    var content = "Hello Kaarel!";
     var contentBytes = content.getBytes(StandardCharsets.UTF_8);
 
     var batches = 100;

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MessagesInterceptionTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MessagesInterceptionTest.java
@@ -39,9 +39,9 @@ class MessagesInterceptionTest extends BaseIntTest {
 
   @Test
   void messagesCanBeIntercepted() {
-    byte[] someValue = "Hello World!".getBytes(StandardCharsets.UTF_8);
+    byte[] someValue = "Hello Kaspar!".getBytes(StandardCharsets.UTF_8);
 
-    final AtomicInteger bmessageInterceptionsCount = new AtomicInteger();
+    final AtomicInteger messageInterceptionsCount = new AtomicInteger();
 
     testMessagesInterceptor.setBeforeSendingToKafkaFunction(records -> {
       Map<Integer, MessageInterceptionDecision> result = new HashMap<>();
@@ -51,7 +51,7 @@ class MessagesInterceptionTest extends BaseIntTest {
         if ("A".equals(key)) {
           result.put(k, MessageInterceptionDecision.NEUTRAL);
         } else if ("B".equals(key)) {
-          if (bmessageInterceptionsCount.getAndIncrement() < 2) {
+          if (messageInterceptionsCount.getAndIncrement() < 2) {
             log.info("Retrying '" + key + "'.");
             result.put(k, MessageInterceptionDecision.RETRY);
           } else {
@@ -76,7 +76,7 @@ class MessagesInterceptionTest extends BaseIntTest {
 
     await().atMost(Duration.ofMinutes(5)).until(() -> tkmsSentMessagesCollector.getSentMessages(topic).size() == 2);
 
-    assertThat(bmessageInterceptionsCount.get()).isEqualTo(3);
+    assertThat(messageInterceptionsCount.get()).isEqualTo(3);
     var messages = tkmsSentMessagesCollector.getSentMessages(topic);
     assertThat(messages.size()).isEqualTo(2);
     assertThat(messages.get(0).getProducerRecord().key()).isEqualTo("A");

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MonitoringIntTest.java
@@ -25,12 +25,7 @@ class MonitoringIntTest extends BaseIntTest {
   @Test
   void testThatTableStatsMetricsArePresent() {
     Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find("tw_tkms_dao_rows_in_table_stats").tags("shard", "1", "partition", "0").gauge();
-      return gauge != null && gauge.value() == 1_000_000;
-    });
-
-    Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find("tw_tkms_dao_rows_in_index_stats").tags("shard", "1", "partition", "0").gauge();
+      Gauge gauge = meterRegistry.find("tw_tkms_dao_rows_in_engine_independent_table_stats").tags("shard", "1", "partition", "0").gauge();
       return gauge != null && gauge.value() == 1_000_000;
     });
   }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/PostgresEndToEndIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/PostgresEndToEndIntTest.java
@@ -11,12 +11,12 @@ public class PostgresEndToEndIntTest extends EndToEndIntTest {
 
   private static Stream<Arguments> compressionInput() {
     return Stream.of(
-        Arguments.of(CompressionAlgorithm.GZIP, 112),
-        Arguments.of(CompressionAlgorithm.NONE, 1271),
-        Arguments.of(CompressionAlgorithm.LZ4, 135),
-        Arguments.of(CompressionAlgorithm.SNAPPY, 167),
-        Arguments.of(CompressionAlgorithm.SNAPPY_FRAMED, 165),
-        Arguments.of(CompressionAlgorithm.ZSTD, 101)
+        Arguments.of(CompressionAlgorithm.GZIP, 111),
+        Arguments.of(CompressionAlgorithm.NONE, 1171),
+        Arguments.of(CompressionAlgorithm.LZ4, 134),
+        Arguments.of(CompressionAlgorithm.SNAPPY, 160),
+        Arguments.of(CompressionAlgorithm.SNAPPY_FRAMED, 158),
+        Arguments.of(CompressionAlgorithm.ZSTD, 100)
     );
   }
 

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/PostgresMonitoringIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/PostgresMonitoringIntTest.java
@@ -1,7 +1,5 @@
 package com.transferwise.kafka.tkms;
 
-import io.micrometer.core.instrument.Gauge;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -10,9 +8,5 @@ public class PostgresMonitoringIntTest extends MonitoringIntTest {
 
   @Test
   void testThatTableStatsMetricsArePresent() {
-    Awaitility.await().until(() -> {
-      Gauge gauge = meterRegistry.find("tw_tkms_dao_rows_in_table_stats").tags("shard", "1", "partition", "0").gauge();
-      return gauge != null && gauge.value() == 1_000_000;
-    });
   }
 }

--- a/tw-tkms-starter/src/test/java/db/migration/earliestmessage/V2__Init.java
+++ b/tw-tkms-starter/src/test/java/db/migration/earliestmessage/V2__Init.java
@@ -21,7 +21,6 @@ public class V2__Init extends BaseJavaMigration {
               + ") WITH (autovacuum_analyze_threshold=1000000000, toast_tuple_target=8160) ");
           log.info("Create table `" + tableName + "'.");
 
-          stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN id SET (n_distinct=1000000);");
           stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN message SET STORAGE EXTERNAL");
           stmt.executeUpdate("VACUUM FULL " + tableName);
         } finally {

--- a/tw-tkms-starter/src/test/java/db/migration/postgres/V1__Init.java
+++ b/tw-tkms-starter/src/test/java/db/migration/postgres/V1__Init.java
@@ -20,7 +20,6 @@ public class V1__Init extends BaseJavaMigration {
               + ") WITH (autovacuum_analyze_threshold=1000000000, toast_tuple_target=8160) ");
           log.info("Create table `" + tableName + "'.");
 
-          stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN id SET (n_distinct=1000000);");
           stmt.executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN message SET STORAGE EXTERNAL");
           stmt.executeUpdate("VACUUM FULL " + tableName);
         }


### PR DESCRIPTION
## Context

The changes are motivated by our DBAs requesting to lower the tickets for granting services permissions to change innodb table and index stats.

### Changed

* When engine independent stats are enabled in MariaDb, we only check if statistics are fixated in those.

* Consequently, in documentation we only ask to fixate engine independent statistics.

### Removed

* All around recommending to fixate `n_distinct` table parameter.
  It actually did not seem to work and the correct way is still to rely on `pg_hint_plan` extension.
 

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
