### PR TITLE
Fixed a rare `ConcurrentModificationException` in one of the sqls map.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * A rare `ConcurrentModificationException` in one of the sqls map.
 
+### Changed
+
+* When Postgres `pg_hint_plan` extension validation fails, we will log out given explain plan and expected plan fragment.
+  This would reduce some DBA contacts.
+
 ## [0.22.0] - 2023-03-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.1] - 2023-04-17
+
+### Fixed
+
+* A rare `ConcurrentModificationException` in one of the sqls map.
+
 ## [0.22.0] - 2023-03-29
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -4,8 +4,8 @@
 
 5. Add hierarchical Valid annotations for TkmsProperties.
 
-6. It turns out, than in the polling cycle, the sending messages to the Kafka can be by far the slowest step,
-looking at 95th percentiles. We need to figure out, how to overcome this.
+6. It turns out, that in the polling cycle, the sending messages to the Kafka can be by far the slowest step,
+looking at 95th percentiles. We need to figure out / test, how to overcome this.
 * producer per partition?
 * proper producer configuration - large enough batch sizes, lingering, in flight requests count etc.
 
@@ -18,13 +18,9 @@ We should provide counter about how many messages there are like that. So teams 
 We should also provide a solution to overcome that situation automatically. One option would be to provide a hybrid poll
 solution, where from configurable interval we would poll all the messages/tuples.
 
-8. `validateIndexHintsExtension` nees to log the explain plans on failure. So we don't have to ask that info from DBAs.
-
 9. Investigate timeouts on partition leader change.
 
-Sometimes people get errors like:  org.apache.kafka.common.errors.TimeoutException: Expiring 1 record(s) for RulesFeatureAssembler.in.FeatureGatheringResponse-13:10004 ms has passed since batch creation
-
-
+Sometimes people get errors like:  `org.apache.kafka.common.errors.TimeoutException: Expiring 1 record(s) for RulesFeatureAssembler.in.FeatureGatheringResponse-13:10004 ms has passed since batch creation`
 Tamás
 i think tw-tkms is being a bit too restrictive with the delivery timeout config: https://github.com/transferwise/tw-tkms/blob/15b992aa78f397840b0603970fd10ff90a1b6[…]m/transferwise/kafka/tkms/config/TkmsKafkaProducerProvider.java
 it is set to 10 secs, whereas the kafka default is 2 minutes: https://kafka.apache.org/documentation/#producerconfigs_delivery.timeout.ms

--- a/TODO.md
+++ b/TODO.md
@@ -9,3 +9,31 @@ looking at 95th percentiles. We need to figure out, how to overcome this.
 * producer per partition?
 * proper producer configuration - large enough batch sizes, lingering, in flight requests count etc.
 
+7. When earliest visible messages is enabled, but we have left over messages, we currently just log out that they exist.
+
+This is not sufficient.
+
+We should provide counter about how many messages there are like that. So teams can have metric based alerts.
+
+We should also provide a solution to overcome that situation automatically. One option would be to provide a hybrid poll
+solution, where from configurable interval we would poll all the messages/tuples.
+
+8. `validateIndexHintsExtension` nees to log the explain plans on failure. So we don't have to ask that info from DBAs.
+
+9. Investigate timeouts on partition leader change.
+
+Sometimes people get errors like:  org.apache.kafka.common.errors.TimeoutException: Expiring 1 record(s) for RulesFeatureAssembler.in.FeatureGatheringResponse-13:10004 ms has passed since batch creation
+
+
+Tamás
+i think tw-tkms is being a bit too restrictive with the delivery timeout config: https://github.com/transferwise/tw-tkms/blob/15b992aa78f397840b0603970fd10ff90a1b6[…]m/transferwise/kafka/tkms/config/TkmsKafkaProducerProvider.java
+it is set to 10 secs, whereas the kafka default is 2 minutes: https://kafka.apache.org/documentation/#producerconfigs_delivery.timeout.ms
+it seems that the 10 sec is not always enough to handle a partition leadership change - maybe with a bit larger value automatic retries could recover the message sending and we wouldn’t get the TimeoutException
+any thoughts about this
+
+Levani
+Problem here is not a leadership change on the broker, which is usually fast, but that producers have an old metadata cache and this exception forces the producer to refresh the metadata about the brokers. It’s possible to configure the clients to have more frequent metedata refresh (metadata.max.age config), but there will always be some noise around this unless producer internal mechanisms of detecting the stale matadata changes.
+I’m not aware of any KIPs that addresses this, there’s strictly uniform partitioner proposal, but it solves a bit different problem.
+It’s possible to have our own partitioner and producer interceptor to avoid downed brokers (that’s what Twitter did when they adopted Kafka), maybe worth to experiment around it at some point. I think we will get more ideas about this at Kafka Summit this year :slightly_smiling_face:
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.22.0
+version=0.22.1

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
@@ -16,7 +16,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +48,7 @@ public abstract class TkmsDao implements ITkmsDao {
   private Map<TkmsShardPartition, String> getMessagesSqls = new ConcurrentHashMap<>();
   private Map<Pair<TkmsShardPartition, Integer>, String> deleteSqlsMap = new ConcurrentHashMap<>();
 
-  private Map<TkmsShardPartition, Set<Integer>> deleteBatchSizesMap = new HashMap<>();
+  private Map<TkmsShardPartition, Set<Integer>> deleteBatchSizesMap = new ConcurrentHashMap<>();
 
   protected Map<Pair<TkmsShardPartition, String>, String> sqlCache = new ConcurrentHashMap<>();
 

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
@@ -46,9 +46,9 @@ public abstract class TkmsDao implements ITkmsDao {
 
   private Map<TkmsShardPartition, String> insertMessageSqls = new ConcurrentHashMap<>();
   private Map<TkmsShardPartition, String> getMessagesSqls = new ConcurrentHashMap<>();
-  private Map<Pair<TkmsShardPartition, Integer>, String> deleteSqlsMap = new ConcurrentHashMap<>();
+  private Map<Pair<TkmsShardPartition, Integer>, String> deleteSqls = new ConcurrentHashMap<>();
 
-  private Map<TkmsShardPartition, Set<Integer>> deleteBatchSizesMap = new ConcurrentHashMap<>();
+  private Map<TkmsShardPartition, Set<Integer>> deleteBatchSizes = new ConcurrentHashMap<>();
 
   protected Map<Pair<TkmsShardPartition, String>, String> sqlCache = new ConcurrentHashMap<>();
 
@@ -238,7 +238,7 @@ public abstract class TkmsDao implements ITkmsDao {
   @Override
   public void deleteMessages(TkmsShardPartition shardPartition, List<Long> ids) {
     var batchSizeExists =
-        deleteBatchSizesMap.computeIfAbsent(shardPartition, k -> new HashSet<>(properties.getDeleteBatchSizes(k.getShard()))).contains(ids.size());
+        deleteBatchSizes.computeIfAbsent(shardPartition, k -> new HashSet<>(properties.getDeleteBatchSizes(k.getShard()))).contains(ids.size());
 
     if (batchSizeExists) {
       // There will be one query only, no need for explicit transaction.
@@ -312,7 +312,7 @@ public abstract class TkmsDao implements ITkmsDao {
     for (int batchSize : properties.getDeleteBatchSizes(shardPartition.getShard())) {
       while (ids.size() - processedCount >= batchSize) {
         Pair<TkmsShardPartition, Integer> p = ImmutablePair.of(shardPartition, batchSize);
-        String sql = deleteSqlsMap.computeIfAbsent(p, k -> getDeleteSql(shardPartition, batchSize));
+        String sql = deleteSqls.computeIfAbsent(p, k -> getDeleteSql(shardPartition, batchSize));
 
         int finalProcessedCount = processedCount;
         jdbcTemplate.update(sql, ps -> {

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
@@ -123,7 +123,7 @@ public class TkmsPostgresDao extends TkmsDao {
     if (explainResult.contains(expectedPlan)) {
       return true;
     } else {
-      log.info("Explain plan was '{}', and it did not contain '{}'.", explainResult, expectedPlan);
+      log.info("When checking index hint '{}', the explain plan was '{}', and it did not contain '{}'.", hint, explainResult, expectedPlan);
       return false;
     }
   }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
@@ -97,7 +97,7 @@ public class TkmsPostgresDao extends TkmsDao {
     }
 
     super.validateDatabase();
-    
+
     validateIndexHintsExtension();
   }
 
@@ -120,7 +120,12 @@ public class TkmsPostgresDao extends TkmsDao {
   protected boolean doesRespectHint(String hint, String expectedPlan) {
     var table = getTableName(TkmsShardPartition.of(0, 0));
     var explainResult = getExplainResult("select /*+ " + hint + "(om) */ id from " + table + " om where id = 1");
-    return explainResult.contains(expectedPlan);
+    if (explainResult.contains(expectedPlan)) {
+      return true;
+    } else {
+      log.info("Explain plan was '{}', and it did not contain '{}'.", explainResult, expectedPlan);
+      return false;
+    }
   }
 
   protected String getExplainResult(String sql) {


### PR DESCRIPTION
## Context

Some teams started to get `ConcurrentModificationException`, which seems to be come from changes in `0.22.0`.

https://rollbar.com/Wise/fin/items/19299/

### Fixed

* A rare `ConcurrentModificationException` in one of the sqls map.

### Changed

* When Postgres `pg_hint_plan` extension validation fails, we will log out given explain plan and expected plan fragment.
  This would reduce some DBA contacts.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
