### PR TITLE
Tweak error handling when proxying is stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.1] - 2023-06-15
+
+### Changed
+
+* Fix for hang detection behavior when proxy leader is stopping. The logic, which throws an IllegalStateException with
+  a relevant error message, was not being invoked. A TimeoutException with generic message was being thrown instead.
+
 ## [0.23.0] - 2023-03-29
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.23.0
+version=0.23.1

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsStorageToKafkaProxy.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsStorageToKafkaProxy.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.Data;
@@ -129,10 +130,9 @@ public class TkmsStorageToKafkaProxy implements GracefulShutdownStrategy, ITkmsS
                   Future<Boolean> future = futureReference.get();
                   if (future != null) {
                     try {
-                      Boolean result = future.get(tkmsPaceMaker.getLongWaitTime(shardPartition.getShard()).toMillis(), TimeUnit.MILLISECONDS);
-                      if (result == null) {
-                        throw new IllegalStateException("Hang detected when trying to stop polling of " + shardPartition + ".");
-                      }
+                      future.get(tkmsPaceMaker.getLongWaitTime(shardPartition.getShard()).toMillis(), TimeUnit.MILLISECONDS);
+                    } catch (TimeoutException e) {
+                      throw new IllegalStateException("Hang detected when trying to stop polling of " + shardPartition + ".", e);
                     } catch (Throwable t) {
                       log.error(t.getMessage(), t);
                     }


### PR DESCRIPTION
## Context

When proxying is stopped, we wait for up to 15s for the current proxy cycle to finish. This is accomplished by waiting for a `future.get()` to return.

Current logic has check for null return value, which will never be the case. What can happen, is a TimeoutException, as seen here: https://rollbar.com/Wise/fin/items/14285/

This PR replaces the null check with a catch clause for TimeoutException, and moves the related logic there.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
