### PR TITLE
Bump snappy java dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.1] - 2023-06-22
+
+### Changed
+
+* `org.xerial.snappy:snappy-java` version is bumped from `1.1.9.1` to `1.1.10.1` to avoid vulnerabilities in transitive dependencies.
+
 ## [0.24.0] - 2023-06-16
 
 ### Added

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -14,7 +14,7 @@ ext {
             lz4Java                         : 'org.lz4:lz4-java:1.8.0',
             protobufJava                    : "com.google.protobuf:protobuf-java:${protobufVersion}",
             semver4j                        : "com.vdurmont:semver4j:3.1.0",
-            snappyJava                      : 'org.xerial.snappy:snappy-java:1.1.9.1',
+            snappyJava                      : 'org.xerial.snappy:snappy-java:1.1.10.1',
             spotbugsAnnotations             : "com.github.spotbugs:spotbugs-annotations:${spotbugs.toolVersion.get()}",
             springBootDependencies          : "org.springframework.boot:spring-boot-dependencies:${springBootVersion}",
             twBaseUtils                     : 'com.transferwise.common:tw-base-utils:1.10.1',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.23.1
+version=0.24.1


### PR DESCRIPTION
## Context

Bump of `snappy-java` to `1.1.10.1` fixes several vulnerabilities:

- [CVE-2023-34453](https://nvd.nist.gov/vuln/detail/CVE-2023-34453)
- [CVE-2023-34454](https://nvd.nist.gov/vuln/detail/CVE-2023-34454)
- [CVE-2023-34455](https://nvd.nist.gov/vuln/detail/CVE-2023-34455)

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
