### PR TITLE
Avoiding and softening issues around corrupted messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.0] - 2023-08-09
+
+### Added
+
+* Message id into error logs.
+* Message id into MDC.
+* `validateSerialization` option as a guardrail for corrupted gzip inflation, due to zlib bugs etc.
+
+### Changed
+
+* `protobuf-java` will be shaded to avoid incompatibility issues in services.
+  Articles point out that it is recommended to use the same `protobuf-java` version which was used to generate java stubs (in our case StoredMessage).
+  Even when historically `protobuf-java` has had good backward compatibility then it is not guaranteed. And forward compatibility had been pretty bad
+  in our experience.
+
 ## [0.24.3] - 2023-08-01
 
 ### Added
@@ -37,9 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   In case there is a rare long-running transaction and its messages need to get sent out.
 
 * An option to defer insertion of messages into the database to the very end of a transaction, just before commit
-  - `deferMessageRegistrationUntilCommit`
-    This would generate fairly recent ids for the messages and earliest visible messages system has less chance to not see and thus skip those.
-    With that, the earliest visible message system can configure a fairly small look-back window and reduce CPU consumption even further.
+    - `deferMessageRegistrationUntilCommit`
+      This would generate fairly recent ids for the messages and earliest visible messages system has less chance to not see and thus skip those.
+      With that, the earliest visible message system can configure a fairly small look-back window and reduce CPU consumption even further.
 
   It can also help to reduce total transaction latency, as all individual messages collected are sent out in batches.
 

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -45,6 +45,9 @@ configurations {
     testAnnotationProcessor {
         extendsFrom(local)
     }
+    shadow {
+        extendsFrom(local)
+    }
 
     all {
         resolutionStrategy {

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ plugins {
     id "at.zierler.yamlvalidator" version "1.5.0"
     id 'org.ajoberstar.grgit' version '5.2.0'
     id 'io.github.gradle-nexus.publish-plugin' version "1.1.0"
+    id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
 }
 
 idea.project {

--- a/build.library.gradle
+++ b/build.library.gradle
@@ -76,4 +76,5 @@ publishing {
             }
         }
     }
+    
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.24.3
+version=0.25.0

--- a/tw-tkms-starter/build.gradle
+++ b/tw-tkms-starter/build.gradle
@@ -3,14 +3,19 @@ plugins {
     id 'idea'
     id "com.google.protobuf"
     id "docker-compose"
+    id 'com.github.johnrengelman.shadow'
+    id 'maven-publish'
+    id 'signing'
 }
 
+ext.projectGitHubRepoName = "tw-tkms"
+ext.projectScmUrl = "https://github.com/transferwise/${projectGitHubRepoName}"
+ext.projectScmConnection = "scm:git:git://github.com/transferwise/${projectGitHubRepoName}.git"
 ext.projectName = "tw-tkms-starter"
 ext.projectDescription = "tw-tkms-starter"
 ext.projectArtifactName = "tw-tkms-starter"
 
 apply from: "$rootProject.rootDir/build.common.gradle"
-apply from: "$rootProject.rootDir/build.library.gradle"
 
 dependencies {
     annotationProcessor libraries.springBootConfigurationProcessor
@@ -97,5 +102,118 @@ dockerCompose {
 test {
     doFirst {
         dockerCompose.exposeAsEnvironment(test)
+    }
+}
+
+/*
+   Protobuf version in a service may not be compatible with our generated `StoredMessage`.
+   It is safer and better to shadow the version we used.
+ */
+shadowJar {
+    dependencies {
+        dependencies {
+            exclude(dependency {
+                it.moduleName != 'protobuf-java'
+            })
+        }
+    }
+    manifest {
+        attributes 'Implementation-Version': "$project.version"
+    }
+    relocate('com.google.protobuf', 'com.transferwise.kafka.tkms.shadow.com.google.protobuf')
+    
+    // Minimize does not reduce the jar much (1.9->1.5 MB), so let's not risk/mess with that.
+    /*
+      minimize {}
+    */
+}
+
+jar.enabled = false
+jar.dependsOn shadowJar
+
+shadowJar {
+    archiveClassifier.set('')
+}
+
+publishing {
+    publications {
+        entrypoints(MavenPublication) { publication ->
+            artifactId projectArtifactName
+
+            artifacts = [shadowJar, javadocJar, sourcesJar]
+            /*
+             This ensures that libraries will have explicit dependency versions in their Maven POM and Gradle module files, so that there would be less
+             ambiguity and less chances of dependency conflicts.
+            */
+            versionMapping {
+                usage('java-api') {
+                    fromResolutionOf('runtimeClasspath')
+                }
+                usage('java-runtime') {
+                    fromResolutionOf('runtimeClasspath')
+                }
+            }
+
+            pom {
+                name = projectName
+                description = projectDescription
+                url = projectScmUrl
+                packaging = "jar"
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0, Copyright 2021 TransferWise Ltd'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'onukristo'
+                        name = 'Kristo Kuusküll'
+                        email = "kristo.kuuskull@transferwise.com"
+                        organization = "Transferwise Ltd"
+                        organizationUrl = "https://github.com/transferwise"
+                    }
+                }
+                scm {
+                    connection = projectScmConnection
+                    developerConnection = projectScmConnection
+                    url = projectScmUrl
+                }
+                withXml { xml ->
+                    def dependenciesNode = xml.asNode().get('dependencies') ?: xml.asNode().appendNode('dependencies')
+
+                    project.configurations.getByName("runtimeClasspath").resolvedConfiguration.firstLevelModuleDependencies.forEach {
+                        if (it.configuration != "platform-runtime" && it.moduleName != 'protobuf-java') {
+                            def dependencyNode = dependenciesNode.appendNode('dependency')
+                            dependencyNode.appendNode('groupId', it.moduleGroup)
+                            dependencyNode.appendNode('artifactId', it.moduleName)
+                            dependencyNode.appendNode('version', it.moduleVersion)
+                            dependencyNode.appendNode('scope', 'runtime')
+                        }
+                    }
+
+                    if (!asNode().dependencyManagement.isEmpty()) {
+                        throw new IllegalStateException("There should not be any `dependencyManagement` block in POM.")
+                    }
+                }
+            }
+        }
+    }
+
+    if (System.getenv("OSS_SIGNING_KEY")) {
+        signing {
+            useInMemoryPgpKeys(System.getenv("OSS_SIGNING_KEY"), System.getenv("OSS_SIGNING_PASSWORD"))
+            sign publishing.publications.entrypoints
+        }
+    }
+    
+    repositories {
+        maven {
+            url System.getenv("MAVEN_URL")
+            credentials {
+                username = System.getenv("MAVEN_USER")
+                password = System.getenv("MAVEN_PASSWORD")
+            }
+        }
     }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -186,10 +186,12 @@ public class TkmsProperties implements InitializingBean {
   /**
    * Tries to deserialize a message before writing it into database.
    *
-   * <p>We have had case where JDK's GZIP generated a corrupted output for a message. This in turn stopped the messages proxying.
-   * Enabling this option would allow to detect that situation early on.
+   * <p>We have had a case where JDK's GZIP implementation generated a corrupted output. This in turn stopped the messages proxying, because next
+   * message could not be deserialized.
    *
-   * <p>This has a small CPU and memory allocation hit per every message.
+   * <p>Enabling this option would allow to detect that situation early on and isolate the fault to few messages only.
+   *
+   * <p>It has a small CPU and memory allocation hit per every message.
    */
   private boolean validateSerialization = false;
 

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -184,6 +184,16 @@ public class TkmsProperties implements InitializingBean {
   private Duration proxyStopTimeout = Duration.ofSeconds(15);
 
   /**
+   * Tries to deserialize a message before writing it into database.
+   *
+   * <p>We have had case where JDK's GZIP generated a corrupted output for a message. This in turn stopped the messages proxying.
+   * Enabling this option would allow to detect that situation early on.
+   *
+   * <p>This has a small CPU and memory allocation hit per every message.
+   */
+  private boolean validateSerialization = false;
+
+  /**
    * List topics used by the lib.
    *
    * <p>It is not mandatory, but it allows to do some pre validation and prevent the service starting when something is wrong.
@@ -268,6 +278,11 @@ public class TkmsProperties implements InitializingBean {
     @ResolvedValue
     @LegacyResolvedValue
     private String partitionKey = "tkmsPartition";
+    @NotBlank
+    @jakarta.validation.constraints.NotBlank
+    @ResolvedValue
+    @LegacyResolvedValue
+    private String messageIdKey = "tkmsMessageId";
   }
 
   @Data
@@ -286,6 +301,7 @@ public class TkmsProperties implements InitializingBean {
     private Duration proxyStopTimeout;
     private boolean compressionOverridden;
     private Boolean deferRegisteredMessagesUntilCommit;
+    private Boolean validateSerialization;
     @Valid
     @jakarta.validation.Valid
     private Compression compression = new Compression();
@@ -298,6 +314,14 @@ public class TkmsProperties implements InitializingBean {
     @ResolvedValue
     @LegacyResolvedValue
     private Map<String, String> kafka = new HashMap<>();
+  }
+
+  public boolean isValidateSerialization(int shard) {
+    var shardProperties = shards.get(shard);
+    if (shardProperties != null && shardProperties.getValidateSerialization() != null) {
+      return shardProperties.getValidateSerialization();
+    }
+    return validateSerialization;
   }
 
   public Duration getProxyStopTimeout(int shard) {

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMessageSerializer.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMessageSerializer.java
@@ -21,11 +21,14 @@ import com.transferwise.kafka.tkms.stored_message.StoredMessage.Message;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import net.jpountz.lz4.LZ4BlockInputStream;
 import net.jpountz.lz4.LZ4BlockOutputStream;
 import net.jpountz.lz4.LZ4Factory;
+import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.xerial.snappy.SnappyFramedInputStream;
@@ -53,7 +56,7 @@ public class TkmsMessageSerializer implements ITkmsMessageSerializer {
     Message storedMessage = toStoredMessage(tkmsMessage);
     int serializedSize = storedMessage.getSerializedSize();
 
-    UnsynchronizedByteArrayOutputStream os = new UnsynchronizedByteArrayOutputStream(serializedSize / 4);
+    var os = new UnsynchronizedByteArrayOutputStream(serializedSize / 4);
 
     // 3 byte header for future use
     os.write(0);
@@ -103,7 +106,23 @@ public class TkmsMessageSerializer implements ITkmsMessageSerializer {
 
     metricsTemplate.recordMessageSerialization(shardPartition, compressionAlgorithm, serializedSize, os.size());
 
-    return os.toInputStream();
+    os.flush();
+
+    var serializedBytes = os.toByteArray();
+
+    if (properties.isValidateSerialization(shardPartition.getShard())) {
+      var deSerializedMessage = deserialize(shardPartition, new UnsynchronizedByteArrayInputStream(serializedBytes));
+
+      if (!Arrays.equals(deSerializedMessage.getValue().toByteArray(), tkmsMessage.getValue())
+          || !Objects.equals(deSerializedMessage.getKey(), tkmsMessage.getKey())
+          || !Objects.equals(deSerializedMessage.getTopic(), tkmsMessage.getTopic())
+      ) {
+        throw new IllegalStateException("Data corruption detected. Serialized and deserialized messages are not equal.");
+      }
+
+    }
+
+    return new UnsynchronizedByteArrayInputStream(serializedBytes);
   }
 
   @Override
@@ -114,7 +133,7 @@ public class TkmsMessageSerializer implements ITkmsMessageSerializer {
     is.read();
     byte h2 = (byte) is.read();
 
-    InputStream decompressedStream = decompress(h2, is);
+    var decompressedStream = decompress(h2, is);
     try {
       return StoredMessage.Message.parseFrom(decompressedStream);
     } finally {
@@ -123,33 +142,33 @@ public class TkmsMessageSerializer implements ITkmsMessageSerializer {
   }
 
   protected void compressSnappy(StoredMessage.Message storedMessage, OutputStream out, Integer blockSize) throws IOException {
-    try (SnappyOutputStream compressOut = new SnappyOutputStream(out, blockSize == null ? 32 * 1024 : blockSize)) {
+    try (var compressOut = new SnappyOutputStream(out, blockSize == null ? 32 * 1024 : blockSize)) {
       storedMessage.writeTo(compressOut);
     }
   }
 
   protected void compressSnappyFramed(StoredMessage.Message storedMessage, OutputStream out, Integer blockSize) throws IOException {
-    try (SnappyFramedOutputStream compressOut = new SnappyFramedOutputStream(out,
+    try (var compressOut = new SnappyFramedOutputStream(out,
         blockSize == null ? SnappyFramedOutputStream.DEFAULT_BLOCK_SIZE : blockSize, DEFAULT_MIN_COMPRESSION_RATIO)) {
       storedMessage.writeTo(compressOut);
     }
   }
 
   protected void compressZstd(StoredMessage.Message storedMessage, OutputStream out, Integer level) throws IOException {
-    try (ZstdOutputStream compressOut = level == null ? new ZstdOutputStream(out) : new ZstdOutputStream(out, level)) {
+    try (var compressOut = level == null ? new ZstdOutputStream(out) : new ZstdOutputStream(out, level)) {
       storedMessage.writeTo(compressOut);
     }
   }
 
   protected void compressLz4(StoredMessage.Message storedMessage, OutputStream out, Integer blockSize) throws IOException {
-    try (LZ4BlockOutputStream compressOut = new LZ4BlockOutputStream(out, blockSize == null ? 1 << 16 : blockSize,
+    try (var compressOut = new LZ4BlockOutputStream(out, blockSize == null ? 1 << 16 : blockSize,
         LZ4Factory.fastestJavaInstance().fastCompressor())) {
       storedMessage.writeTo(compressOut);
     }
   }
 
   protected void compressGzip(StoredMessage.Message storedMessage, OutputStream out) throws IOException {
-    try (GZIPOutputStream compressOut = new GZIPOutputStream(out)) {
+    try (var compressOut = new GZIPOutputStream(out)) {
       storedMessage.writeTo(compressOut);
     }
   }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMessageSerializer.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMessageSerializer.java
@@ -114,15 +114,21 @@ public class TkmsMessageSerializer implements ITkmsMessageSerializer {
       var deSerializedMessage = deserialize(shardPartition, new UnsynchronizedByteArrayInputStream(serializedBytes));
 
       if (!Arrays.equals(deSerializedMessage.getValue().toByteArray(), tkmsMessage.getValue())
-          || !Objects.equals(deSerializedMessage.getKey(), tkmsMessage.getKey())
-          || !Objects.equals(deSerializedMessage.getTopic(), tkmsMessage.getTopic())
+          || !areSimilar(deSerializedMessage.getKey(), tkmsMessage.getKey())
+          || !areSimilar(deSerializedMessage.getTopic(), tkmsMessage.getTopic())
       ) {
         throw new IllegalStateException("Data corruption detected. Serialized and deserialized messages are not equal.");
       }
-
     }
 
     return new UnsynchronizedByteArrayInputStream(serializedBytes);
+  }
+
+  private boolean areSimilar(String s0, String s1) {
+    if ((s0 == null || s0.length() == 0) && (s1 == null || s1.length() == 0)) {
+      return true;
+    }
+    return Objects.equals(s0, s1);
   }
 
   @Override

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
@@ -84,6 +84,7 @@ abstract class EndToEndIntTest extends BaseIntTest {
     tkmsStorageToKafkaProxy.setTkmsDaoProvider(tkmsDaoProvider);
     ((TransactionalKafkaMessageSender) transactionalKafkaMessageSender).setTkmsDaoProvider(tkmsDaoProvider);
     tkmsProperties.setDeferMessageRegistrationUntilCommit(false);
+    tkmsProperties.setValidateSerialization(false);
   }
 
   protected void setupConfig(boolean deferUntilCommit) {
@@ -159,9 +160,13 @@ abstract class EndToEndIntTest extends BaseIntTest {
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void testExactlyOnceDelivery(boolean deferUntilCommit) throws Exception {
+  @ValueSource(ints = {0, 1, 2, 3})
+  void testExactlyOnceDelivery(int scenario) throws Exception {
+    var deferUntilCommit = scenario == 0 || scenario == 2;
+    var validateSerialization = scenario == 1 || scenario == 3;
+
     setupConfig(deferUntilCommit);
+    tkmsProperties.setValidateSerialization(validateSerialization);
 
     String message = "Hello World!";
     int threadsCount = 20;


### PR DESCRIPTION
## Context

### Added

* Message id into error logs.
* Message id into MDC.
* `validateSerialization` option as a guardrail for corrupted gzip inflation, due to zlib bugs etc.

### Changed

* `protobuf-java` will be shaded to avoid incompatibility issues in services.
  Articles point out that it is recommended to use the same `protobuf-java` version which was used to generate java stubs (in our case StoredMessage).
  Even when historically `protobuf-java` has had good backward compatibility then it is not guaranteed. And forward compatibility had been pretty bad
  in our experience.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
