### PR TITLE
[VERAT-442] Update docs, new default kafka bootstrap server env variable

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,7 +27,7 @@ Minimum required configuration is:
 ```
 tw-tkms:
   database-dialect: POSTGRES # only required if using Postgres, MariaDb is the default
-  kafka.bootstrap.servers: ${ENV_SECURE_KAFKA_BOOTSTRAP_SERVERS}
+  kafka.bootstrap.servers: ${ENV_SECURE_KAFKA_DISCOVERY_BOOTSTRAP_SERVER}
   environment:
     previous-version-at-least: ${LIB_VERSION} # use current lib version for a new integration
 ```


### PR DESCRIPTION
## Context

Current default variable for kafka bootstrap servers is: `${ENV_SECURE_KAFKA_DISCOVERY_BOOTSTRAP_SERVER}`
Reflect in docs, to make life easier and avoid confusing errors.

[VERAT-442](https://transferwise.atlassian.net/browse/VERAT-442) 

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 


[VERAT-442]: https://transferwise.atlassian.net/browse/VERAT-442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ