### PR TITLE
Topic validation is using a kafka producer per shard.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,10 @@ jobs:
       IN_CI: true
       MARIADB_TCP_3306: 3306
       MARIADB_TCP_HOST: mysql1
-      TW_TKMS_KAFKA_TCP_9092: 9092
-      TW_TKMS_KAFKA_TCP_HOST: kafka1
+      TW_TKMS_KAFKA_1_TCP_9092: 9092
+      TW_TKMS_KAFKA_1_TCP_HOST: kafka1
+      TW_TKMS_KAFKA_2_TCP_9092: 9092
+      TW_TKMS_KAFKA_2_TCP_HOST: kafka2
       ZOOKEEPER_TCP_2181: 2181
       ZOOKEEPER_TCP_HOST: zookeeper1
       POSTGRES_TCP_HOST: postgres1
@@ -54,7 +56,19 @@ jobs:
         image: wurstmeister/kafka:2.12-2.2.0
         env:
           KAFKA_BROKER_ID: 1
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper1:2181
+          KAFKA_ZOOKEEPER_CONNECT: zookeeper1:2181/kafka1
+          KAFKA_LISTENERS: PLAINTEXT://:9092
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+          KAFKA_MESSAGE_MAX_BYTES: "10485760"
+          KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS: 20000
+          KAFKA_UNCLEAN_LEADER_ELECTION_ENABLE: "true"
+          KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS: 5
+          KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      kafka2:
+        image: wurstmeister/kafka:2.12-2.2.0
+        env:
+          KAFKA_BROKER_ID: 1
+          KAFKA_ZOOKEEPER_CONNECT: zookeeper1:2181/kafka2
           KAFKA_LISTENERS: PLAINTEXT://:9092
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
           KAFKA_MESSAGE_MAX_BYTES: "10485760"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.1] - 2024-01-12
+
+### Fixed
+
+- Topic validator is using a Kafka producer per shard.
+  This would ensure, that a right Kafka settings are used.
+  As different shards can have a different Kafka server behind them.
+
 ## [0.28.0] - 2023-12-20
 
 ### Changed

--- a/demoapp/src/main/resources/application.yml
+++ b/demoapp/src/main/resources/application.yml
@@ -28,7 +28,6 @@ spring:
     locations: "classpath:db/migration/mysql"
 tw-tkms:
   polling-interval: 5ms
-  shards-count: 1
   partitions-count: 1
   topics:
     - ComplexTest

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.28.0
+version=0.28.1

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsTopicValidator.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsTopicValidator.java
@@ -18,13 +18,15 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -80,44 +82,66 @@ public class TkmsTopicValidator implements ITkmsTopicValidator, InitializingBean
 
   @Override
   public void preValidateAll() {
-    final var topics = tkmsProperties.getTopics();
 
     final var semaphore = new Semaphore(tkmsProperties.getTopicValidation().getValidationConcurrencyAtInitialization());
     final var failures = new AtomicInteger();
-    final var countDownLatch = new CountDownLatch(topics.size());
+    final var phaser = new Phaser(1);
     final var startTimeEpochMs = System.currentTimeMillis();
 
-    for (var topic : topics) {
-      topicsValidatedDuringInitializationOrNotified.put(topic, Boolean.TRUE);
-      final var timeoutMs =
-          tkmsProperties.getTopicValidation().getTopicPreValidationTimeout().toMillis() - System.currentTimeMillis() + startTimeEpochMs;
-      if (ExceptionUtils.doUnchecked(() -> semaphore.tryAcquire(timeoutMs, TimeUnit.MILLISECONDS))) {
-        /*
-          We are validating one by one, to get the proper error messages from Kafka.
-          And, we are doing it concurrently to speed things up.
-         */
-        executor.execute(() -> {
-          try {
-            validate(TkmsShardPartition.of(tkmsProperties.getDefaultShard(), 0), topic, null);
+    for (int shard = 0; shard < tkmsProperties.getShardsCount(); shard++) {
+      var shardProperties = tkmsProperties.getShards().get(shard);
+      List<String> shardTopics = shardProperties == null ? null : shardProperties.getTopics();
 
-            log.info("Topic '{}' successfully pre-validated.", topic);
-          } catch (Throwable t) {
-            log.error("Topic validation for '" + topic + "' failed.", t);
-            failures.incrementAndGet();
-          } finally {
-            countDownLatch.countDown();
-            semaphore.release();
-          }
-        });
-      } else {
-        break;
+      if (shardTopics != null && shard == tkmsProperties.getDefaultShard()) {
+        throw new IllegalStateException("Topics for default shard have to be specified on 'tw-tkms.topics' property.");
+      }
+
+      if (shard == tkmsProperties.getDefaultShard()) {
+        shardTopics = tkmsProperties.getTopics();
+      }
+
+      if (shardTopics == null) {
+        continue;
+      }
+
+      for (var topic : shardTopics) {
+        topicsValidatedDuringInitializationOrNotified.put(topic, Boolean.TRUE);
+        final var timeoutMs =
+            tkmsProperties.getTopicValidation().getTopicPreValidationTimeout().toMillis() - System.currentTimeMillis() + startTimeEpochMs;
+        if (ExceptionUtils.doUnchecked(() -> semaphore.tryAcquire(timeoutMs, TimeUnit.MILLISECONDS))) {
+
+          final var finalShard = shard;
+          /*
+            We are validating one by one, to get the proper error messages from Kafka.
+            And, we are doing it concurrently to speed things up.
+           */
+          phaser.register();
+          executor.execute(() -> {
+            try {
+              validate(TkmsShardPartition.of(finalShard, 0), topic, null);
+
+              log.info("Topic '{}' successfully pre-validated.", topic);
+            } catch (Throwable t) {
+              log.error("Topic validation for '" + topic + "' failed.", t);
+              failures.incrementAndGet();
+            } finally {
+              phaser.arriveAndDeregister();
+              semaphore.release();
+            }
+          });
+        } else {
+          break;
+        }
       }
     }
 
     final var timeoutMs =
         tkmsProperties.getTopicValidation().getTopicPreValidationTimeout().toMillis() - System.currentTimeMillis() + startTimeEpochMs;
 
-    if (!ExceptionUtils.doUnchecked(() -> countDownLatch.await(timeoutMs, TimeUnit.MILLISECONDS))) {
+    int phase = phaser.arrive();
+    try {
+      phaser.awaitAdvanceInterruptibly(phase, timeoutMs, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException | TimeoutException e) {
       tkmsKafkaProducerProvider.closeKafkaProducerForTopicValidation();
       throw new IllegalStateException("Topic validation is taking too long.");
     }
@@ -133,7 +157,7 @@ public class TkmsTopicValidator implements ITkmsTopicValidator, InitializingBean
     if (tkmsProperties.getTopicValidation().isUseAdminClient()) {
       validateUsingAdmin(shardPartition, topic, partition);
     } else {
-      validateUsingProducer(topic);
+      validateUsingProducer(shardPartition, topic);
     }
   }
 
@@ -146,7 +170,10 @@ public class TkmsTopicValidator implements ITkmsTopicValidator, InitializingBean
       return Boolean.TRUE;
     });
 
-    var response = topicDescriptionsCache.get(new FetchTopicDescriptionRequest().setTopic(topic));
+    var response = topicDescriptionsCache.get(new FetchTopicDescriptionRequest()
+        .setTopic(topic)
+        .setShardPartition(shardPartition)
+    );
 
     if (response == null) {
       throw new NullPointerException("Could not fetch topic description for topic '" + topic + "'.");
@@ -185,8 +212,8 @@ public class TkmsTopicValidator implements ITkmsTopicValidator, InitializingBean
     Legacy logic.
     We keep it in, in case some service would run into issues with the admin client based validation.
    */
-  protected void validateUsingProducer(String topic) {
-    tkmsKafkaProducerProvider.getKafkaProducerForTopicValidation().partitionsFor(topic);
+  protected void validateUsingProducer(TkmsShardPartition shardPartition, String topic) {
+    tkmsKafkaProducerProvider.getKafkaProducerForTopicValidation(shardPartition).partitionsFor(topic);
   }
 
   protected FetchTopicDescriptionResponse fetchTopicDescription(FetchTopicDescriptionRequest request) {
@@ -197,7 +224,7 @@ public class TkmsTopicValidator implements ITkmsTopicValidator, InitializingBean
         && tkmsProperties.getTopicValidation().isTryToAutoCreateTopics()) {
       final var topic = request.getTopic();
       try {
-        validateUsingProducer(topic);
+        validateUsingProducer(request.getShardPartition(), topic);
 
         log.info("Succeeded in auto creating topic `{}`", topic);
 

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSender.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSender.java
@@ -519,6 +519,7 @@ public class TransactionalKafkaMessageSender implements ITransactionalKafkaMessa
   @Data
   @Accessors(chain = true)
   protected static class FetchTopicDescriptionRequest {
+
     private TkmsShardPartition shardPartition;
     private String topic;
   }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSender.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSender.java
@@ -519,7 +519,7 @@ public class TransactionalKafkaMessageSender implements ITransactionalKafkaMessa
   @Data
   @Accessors(chain = true)
   protected static class FetchTopicDescriptionRequest {
-
+    private TkmsShardPartition shardPartition;
     private String topic;
   }
 

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/ITkmsKafkaAdminProvider.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/ITkmsKafkaAdminProvider.java
@@ -1,11 +1,12 @@
 package com.transferwise.kafka.tkms.config;
 
+import com.transferwise.kafka.tkms.api.TkmsShardPartition;
 import org.apache.kafka.clients.admin.Admin;
 
 public interface ITkmsKafkaAdminProvider {
 
-  Admin getKafkaAdmin();
+  Admin getKafkaAdmin(TkmsShardPartition tkmsShardPartition);
 
-  void closeKafkaAdmin();
+  void closeKafkaAdmin(TkmsShardPartition tkmsShardPartition);
 
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/ITkmsKafkaProducerProvider.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/ITkmsKafkaProducerProvider.java
@@ -11,7 +11,9 @@ public interface ITkmsKafkaProducerProvider {
 
   void closeKafkaProducer(TkmsShardPartition tkmsShardPartition, UseCase useCase);
 
-  void closeKafkaProducerForTopicValidation();
+  void closeKafkaProducerForTopicValidation(TkmsShardPartition tkmsShardPartition);
+
+  void closeKafkaProducersForTopicValidation();
 
   enum UseCase {
     PROXY,

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/ITkmsKafkaProducerProvider.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/ITkmsKafkaProducerProvider.java
@@ -7,7 +7,7 @@ public interface ITkmsKafkaProducerProvider {
 
   KafkaProducer<String, byte[]> getKafkaProducer(TkmsShardPartition tkmsShardPartition, UseCase useCase);
 
-  KafkaProducer<String, byte[]> getKafkaProducerForTopicValidation();
+  KafkaProducer<String, byte[]> getKafkaProducerForTopicValidation(TkmsShardPartition shardPartition);
 
   void closeKafkaProducer(TkmsShardPartition tkmsShardPartition, UseCase useCase);
 

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsKafkaProducerProvider.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsKafkaProducerProvider.java
@@ -82,8 +82,8 @@ public class TkmsKafkaProducerProvider implements ITkmsKafkaProducerProvider, Gr
   }
 
   @Override
-  public KafkaProducer<String, byte[]> getKafkaProducerForTopicValidation() {
-    return getKafkaProducer(TkmsShardPartition.of(tkmsProperties.getDefaultShard(), 0), UseCase.TOPIC_VALIDATION);
+  public KafkaProducer<String, byte[]> getKafkaProducerForTopicValidation(TkmsShardPartition shardPartition) {
+    return getKafkaProducer(TkmsShardPartition.of(shardPartition.getShard(), 0), UseCase.TOPIC_VALIDATION);
   }
 
   @Override

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -196,6 +196,8 @@ public class TkmsProperties implements InitializingBean {
    * <p>It is not mandatory, but it allows to do some pre validation and prevent the service starting when something is wrong.
    *
    * <p>Also, so we can warm up their metadata, avoiding elevated latencies at the start of the service.
+   *
+   * <p>You may want to list some topics under a specific shard configuration. If those use a different Kafka Server or ACLs or else.
    */
   @ResolvedValue
   @LegacyResolvedValue
@@ -315,6 +317,10 @@ public class TkmsProperties implements InitializingBean {
     @ResolvedValue
     @LegacyResolvedValue
     private Map<String, String> kafka = new HashMap<>();
+
+    @ResolvedValue
+    @LegacyResolvedValue
+    private List<String> topics = new ArrayList<>();
   }
 
   public boolean isValidateSerialization(int shard) {

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageTrackingIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EarliestMessageTrackingIntTest.java
@@ -100,7 +100,7 @@ class EarliestMessageTrackingIntTest extends BaseIntTest {
     earliestMessageTracker.init();
 
     assertThat(earliestMessageTracker.getEarliestMessageId()).isEqualTo(committedValue);
-    
+
     assertThat(pollingAllRecordsHappened);
   }
 

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/EndToEndIntTest.java
@@ -494,7 +494,7 @@ abstract class EndToEndIntTest extends BaseIntTest {
           .hasMessageContaining(expectedMessage);
     } finally {
       // Stop logs spam about not existing topic in metadata.
-      tkmsKafkaProducerProvider.closeKafkaProducerForTopicValidation();
+      tkmsKafkaProducerProvider.closeKafkaProducersForTopicValidation();
     }
   }
 
@@ -702,7 +702,7 @@ abstract class EndToEndIntTest extends BaseIntTest {
       if (receivedValue.equals(message.getValue())) {
         receivedCount.incrementAndGet();
       } else {
-        throw new IllegalStateException("Wrong message received.");
+        throw new IllegalStateException("Wrong message received: " + receivedValue);
       }
     });
 

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/KafkaServerMetricsIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/KafkaServerMetricsIntTest.java
@@ -12,7 +12,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class KafkaMetricsIntTest extends BaseIntTest {
+class KafkaServerMetricsIntTest extends BaseIntTest {
 
 
   @Autowired

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MessagesInterceptionTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MessagesInterceptionTest.java
@@ -11,7 +11,6 @@ import com.transferwise.kafka.tkms.test.BaseIntTest;
 import com.transferwise.kafka.tkms.test.TestMessagesInterceptor;
 import com.transferwise.kafka.tkms.test.TestProperties;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MultiServerTopicValidationIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MultiServerTopicValidationIntTest.java
@@ -1,0 +1,78 @@
+package com.transferwise.kafka.tkms;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHelper;
+import com.transferwise.kafka.tkms.api.ITransactionalKafkaMessageSender;
+import com.transferwise.kafka.tkms.api.TkmsMessage;
+import com.transferwise.kafka.tkms.config.ITkmsKafkaProducerProvider;
+import com.transferwise.kafka.tkms.test.BaseIntTest;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class MultiServerTopicValidationIntTest extends BaseIntTest {
+
+  @Autowired
+  private ITransactionalKafkaMessageSender transactionalKafkaMessageSender;
+  @Autowired
+  private ITransactionsHelper transactionsHelper;
+  @Autowired
+  private ITkmsKafkaProducerProvider tkmsKafkaProducerProvider;
+
+  @AfterEach
+  public void cleanup() {
+    super.cleanup();
+
+    tkmsProperties.getTopicValidation().setUseAdminClient(false);
+    tkmsProperties.getTopicValidation().setTryToAutoCreateTopics(true);
+  }
+
+  private static Stream<Arguments> unknownTopicsMatrix() {
+    return Stream.of(
+        Arguments.of(true),
+        Arguments.of(false)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("unknownTopicsMatrix")
+  @SneakyThrows
+  void sendingToUnknownTopicWillBePreventedWhenTopicAutoCreationIsDisabled(boolean useAdminClient) {
+    tkmsProperties.getTopicValidation().setUseAdminClient(useAdminClient);
+
+    final var notExistingTopic = "NotExistingTopic";
+    final var existingTopicInKafka2 = "TestTopicInAnotherServer";
+
+    assertThatThrownBy(() -> sendMessage(notExistingTopic, null)).hasMessageContaining(notExistingTopic);
+
+    sendMessage("TestTopic", null);
+    sendMessage("TestTopic", tkmsProperties.getDefaultShard());
+
+    assertThatThrownBy(() -> sendMessage(existingTopicInKafka2, null)).hasMessageContaining(existingTopicInKafka2);
+
+    sendMessage(existingTopicInKafka2, 2);
+  }
+
+  protected void sendMessage(String topic, Integer shard) {
+    try {
+      transactionsHelper.withTransaction().run(() -> {
+        var message = new TkmsMessage().setTopic(topic).setValue("Stuff".getBytes(StandardCharsets.UTF_8));
+        if (shard != null) {
+          message.setShard(shard);
+        }
+        transactionalKafkaMessageSender.sendMessage(message);
+      });
+    } catch (Exception e) {
+      throw new RuntimeException("Sending message to topic '" + topic + "' and shard " + shard + " failed.");
+    } finally {
+      // Stop spam of metadata errors.
+      tkmsKafkaProducerProvider.closeKafkaProducersForTopicValidation();
+    }
+  }
+}

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSenderTestServer.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSenderTestServer.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class TransactionalKafkaMessageSenderTest {
+class TransactionalKafkaMessageSenderTestServer {
 
   @Test
   void deleteBatchSizesAreCorrectlyValidated() {

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/config/TkmsKafkaProducerProviderTestServer.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/config/TkmsKafkaProducerProviderTestServer.java
@@ -11,7 +11,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class TkmsKafkaProducerProviderTest extends BaseIntTest {
+class TkmsKafkaProducerProviderTestServer extends BaseIntTest {
 
   @Autowired
   private ITkmsKafkaProducerProvider tkmsKafkaProducerProvider;

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/FaultInjectedTkmsDao.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/FaultInjectedTkmsDao.java
@@ -27,7 +27,7 @@ public class FaultInjectedTkmsDao implements ITkmsDao {
         throw new IllegalStateException("Haha, inserts are failing lol.");
       }
     }
-    
+
     return delegate.insertMessage(shardPartition, message);
   }
 

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/TkmsDaoIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/TkmsDaoIntTest.java
@@ -48,7 +48,7 @@ class TkmsDaoIntTest extends BaseIntTest {
   @ProductionBug("Delete worked, but batches were combined wrongly.")
   void deletingInBatchesWorks() {
     var tkmsDao = tkmsDaoProvider.getTkmsDao(0);
-    
+
     List<Long> records = new ArrayList<>();
     for (int i = 0; i < 1001; i++) {
       records.add(

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/BaseIntTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/BaseIntTest.java
@@ -61,7 +61,6 @@ public class BaseIntTest {
     }
     meterCache.clear();
 
-
     TkmsClockHolder.reset();
   }
 

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestProperties.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestProperties.java
@@ -1,5 +1,7 @@
 package com.transferwise.kafka.tkms.test;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Data;
 import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -12,4 +14,14 @@ import org.springframework.stereotype.Component;
 public class TestProperties {
 
   private String testTopic = "MyTestTopic";
+
+  private List<KafkaServer> kafkaServers = new ArrayList<>();
+
+  @Data
+  public static class KafkaServer {
+
+    private String bootstrapServers;
+
+    private List<String> topics = new ArrayList<>();
+  }
 }

--- a/tw-tkms-starter/src/test/resources/application.yml
+++ b/tw-tkms-starter/src/test/resources/application.yml
@@ -43,6 +43,8 @@ tw-tkms:
           ms: 7
       earliest-visible-messages:
         enabled: true
+      topics:
+        - TestTopic
   compression:
     algorithm: random
     min-size: 10
@@ -81,6 +83,8 @@ tw-tkms:
   delete-batch-sizes: "51, 11, 5, 1"
   topic-validation:
     use-admin-client: true
+  topics:
+    - TestTopicPostgres
 
 # We will not pre-create the topic in order to test the
 tw-tkms-test:

--- a/tw-tkms-starter/src/test/resources/application.yml
+++ b/tw-tkms-starter/src/test/resources/application.yml
@@ -12,7 +12,7 @@ spring:
       transaction-isolation: 2
 
   kafka:
-    bootstrap-servers: "${TW_TKMS_KAFKA_TCP_HOST:localhost}:${TW_TKMS_KAFKA_TCP_9092}"
+    bootstrap-servers: "${TW_TKMS_KAFKA_1_TCP_HOST:localhost}:${TW_TKMS_KAFKA_1_TCP_9092}"
     consumer:
       group-id: ${spring.application.name}
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
@@ -29,12 +29,12 @@ tw-curator:
 
 tw-tkms:
   polling-interval: 5ms
-  shards-count: 2
+  shards-count: 3
   insert-batch-size: 2
   topics:
     - TestTopic
   kafka:
-    bootstrap.servers: "${TW_TKMS_KAFKA_TCP_HOST:localhost}:${TW_TKMS_KAFKA_TCP_9092}"
+    bootstrap.servers: "${TW_TKMS_KAFKA_1_TCP_HOST:localhost}:${TW_TKMS_KAFKA_1_TCP_9092}"
   shards:
     1:
       polling-interval: 6ms
@@ -45,6 +45,9 @@ tw-tkms:
         enabled: true
       topics:
         - TestTopic
+    2:
+      kafka:
+        bootstrap.servers: "${TW_TKMS_KAFKA_2_TCP_HOST:localhost}:${TW_TKMS_KAFKA_2_TCP_9092}"
   compression:
     algorithm: random
     min-size: 10
@@ -54,6 +57,8 @@ tw-tkms:
     start-delay: 0s
   internals:
     assertion-level: 1
+  topic-validation:
+    try-to-auto-create-topics: false
 
 tw-graceful-shutdown:
   clients-reaction-time-ms: 1000
@@ -64,6 +69,13 @@ logging.level:
 
 tw-tkms-test:
   test-topic: TestTopic
+  kafka-servers:
+    - bootstrap-servers: "${TW_TKMS_KAFKA_1_TCP_HOST:localhost}:${TW_TKMS_KAFKA_1_TCP_9092}"
+      topics:
+        - TestTopic
+    - bootstrap-servers: "${TW_TKMS_KAFKA_2_TCP_HOST:localhost}:${TW_TKMS_KAFKA_2_TCP_9092}"
+      topics:
+        - TestTopicInAnotherServer
 ---
 
 spring:
@@ -89,6 +101,13 @@ tw-tkms:
 # We will not pre-create the topic in order to test the
 tw-tkms-test:
   test-topic: TestTopicPostgres
+  kafka-servers:
+    - bootstrap-servers: "${TW_TKMS_KAFKA_1_TCP_HOST:localhost}:${TW_TKMS_KAFKA_1_TCP_9092}"
+      topics:
+        - TestTopicPostgres
+    - bootstrap-servers: "${TW_TKMS_KAFKA_2_TCP_HOST:localhost}:${TW_TKMS_KAFKA_2_TCP_9092}"
+      topics:
+        - TestTopicPostgresAnotherServer
 
 ---
 
@@ -112,7 +131,6 @@ tw-tkms:
     enabled: true
     look-back-period: 10s
     table-name: earliestmessage.tw_tkms_earliest_visible_messages
-  shards-count: 2
   table-base-name: earliestmessage.outgoing_message
   monitoring:
     left-over-messages-check-start-delay: 1s
@@ -123,3 +141,7 @@ tw-tkms:
 
 tw-tkms-test:
   test-topic: TestTopicEarliestMessage
+  kafka-servers:
+    - bootstrap-servers: "${TW_TKMS_KAFKA_1_TCP_HOST:localhost}:${TW_TKMS_KAFKA_1_TCP_9092}"
+      topics:
+        - TestTopicEarliestMessage

--- a/tw-tkms-starter/src/test/resources/docker-compose.yml
+++ b/tw-tkms-starter/src/test/resources/docker-compose.yml
@@ -8,16 +8,41 @@ services:
     environment:
       ALLOW_ANONYMOUS_LOGIN: "yes"
       JVMFLAGS: -server -Xms25m -Xmx512m -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90  -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrent
-  kafka:
+  kafka1:
     image: wurstmeister/kafka:2.12-2.4.1
     ports:
       - "9092"
-    container_name: "tw_tkms_kafka"
+    container_name: "tw_tkms_kafka_1"
     environment:
-      PORT_COMMAND: "docker port $$(docker ps -q -f name=tw_tkms_kafka) 9092/tcp | cut -d: -f2"
+      PORT_COMMAND: "docker port $$(docker ps -q -f name=tw_tkms_kafka_1) 9092/tcp | cut -d: -f2"
       KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: "EXTERNAL://localhost:_{PORT_COMMAND},INTERNAL://kafka:9093"
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181/kafka1
+      KAFKA_ADVERTISED_LISTENERS: "EXTERNAL://localhost:_{PORT_COMMAND},INTERNAL://kafka1:9093"
+      KAFKA_LISTENERS: EXTERNAL://:9092,INTERNAL://:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: EXTERNAL:PLAINTEXT,INTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_MESSAGE_MAX_BYTES: 10485760
+      KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS: 20000
+      KAFKA_UNCLEAN_LEADER_ELECTION_ENABLE: "true"
+      KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS: 5
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      LOG4J_LOGGER_ORG: WARN,STDOUT
+      LOG4J_LOGGER_ORG_APACHE_KAFKA: WARN,STDOUT
+      LOG4J_LOGGER_KAFKA: WARN,STDOUT
+      KAFKA_JVM_PERFORMANCE_OPTS: -server -Xms25m -Xmx512m -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90  -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrent
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  kafka2:
+    image: wurstmeister/kafka:2.12-2.4.1
+    ports:
+      - "9092"
+    container_name: "tw_tkms_kafka_2"
+    environment:
+      PORT_COMMAND: "docker port $$(docker ps -q -f name=tw_tkms_kafka_2) 9092/tcp | cut -d: -f2"
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181/kafka2
+      KAFKA_ADVERTISED_LISTENERS: "EXTERNAL://localhost:_{PORT_COMMAND},INTERNAL://kafka2:9093"
       KAFKA_LISTENERS: EXTERNAL://:9092,INTERNAL://:9093
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: EXTERNAL:PLAINTEXT,INTERNAL:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL


### PR DESCRIPTION
## Context

### Fixed

- Topic validator is using a Kafka producer per shard.
  This would ensure, that a right Kafka settings are used.
  As different shards can have a different Kafka server behind them.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
