### PR TITLE
Fixes an improper error message during topic validation initialisation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.2] - 2024-01-25
+
+### Fixed
+
+- Error message "Topics for default shard have to be specified on 'tw-tkms.topics' property." given, when default shard was not defining any topics.
+
 ## [0.28.1] - 2024-01-12
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.28.1
+version=0.28.2

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsTopicValidator.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsTopicValidator.java
@@ -92,7 +92,7 @@ public class TkmsTopicValidator implements ITkmsTopicValidator, InitializingBean
       var shardProperties = tkmsProperties.getShards().get(shard);
       List<String> shardTopics = shardProperties == null ? null : shardProperties.getTopics();
 
-      if (shardTopics != null && shard == tkmsProperties.getDefaultShard()) {
+      if (shardTopics != null && !shardTopics.isEmpty() && shard == tkmsProperties.getDefaultShard()) {
         throw new IllegalStateException("Topics for default shard have to be specified on 'tw-tkms.topics' property.");
       }
 

--- a/tw-tkms-starter/src/test/resources/application.yml
+++ b/tw-tkms-starter/src/test/resources/application.yml
@@ -36,6 +36,9 @@ tw-tkms:
   kafka:
     bootstrap.servers: "${TW_TKMS_KAFKA_1_TCP_HOST:localhost}:${TW_TKMS_KAFKA_1_TCP_9092}"
   shards:
+    # Covers a bug with topics validation
+    0:
+      polling-interval: 6ms
     1:
       polling-interval: 6ms
       kafka:


### PR DESCRIPTION
## Context

Error message "Topics for default shard have to be specified on 'tw-tkms.topics' property." given, when default shard was not defining any topics.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
