### PR TITLE
[APPENG-849] Fix prometheus client cant cast metric type gauge to info issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.1] 2024-07-25
+### Fixed
+- Fixed the prometheus metrics cant cast metric type gauge to info issue.
+
 ## [0.29.0] - 2024-07-16
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.29.0
+version=0.29.1

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
@@ -34,7 +34,9 @@ import org.springframework.beans.factory.InitializingBean;
 @Slf4j
 public class TkmsMetricsTemplate implements ITkmsMetricsTemplate, InitializingBean {
 
-  public static final String GAUGE_LIBRARY_INFO = "tw_library_info";
+  // Miccrometer 1.13 (which comes with Spring boot 3.3) doesn't properly convert gauge metrics with info suffix when using underscore,
+  // using dot here as a workaround
+  public static final String GAUGE_LIBRARY_INFO = "tw.library.info";
   public static final String TIMER_PROXY_POLL = "tw_tkms_proxy_poll";
   public static final String GAUGE_PROXY_POLL_IN_PROGRESS = "tw_tkms_proxy_poll_in_progress";
   public static final String TIMER_PROXY_CYCLE = "tw_tkms_proxy_cycle";


### PR DESCRIPTION
## Context
This pull request attempts to fix the micrometer prometheus metrics cant cast metric type gauge to info issue by using dot based format as a workaround. 

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 


## Details from ticket: [APPENG-849](https://transferwise.atlassian.net/browse/APPENG-849)

### Update platform libraries matrix tests to run with boot 3.3

>Tracking the specific libraries here:
>
>[https://docs.google.com/spreadsheets/d/1cogv7V6ofZv1urcBYYrj91f3VzKg-e92DltiiRgqndc/edit?gid=618138693#gid=618138693a|https://docs.google.com/spreadsheets/d/1cogv7V6ofZv1urcBYYrj91f3VzKg-e92DltiiRgqndc/edit?gid=618138693#gid=618138693a|smart-link] 


[APPENG-849]: https://transferwise.atlassian.net/browse/APPENG-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ