### PR TITLE
[PPP-502] TKMS - Add decorator for message headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.30.0] 2024-07-25
+## [0.30.0] 2024-08-06
 ### Added
 - Added `ITkmsMessageDecorator` that kicks in before message is registered and adds custom headers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.0] 2024-07-25
+### Added
+- Added `ITkmsMessageDecorator` that kicks in before message is registered and adds custom headers
+
 ## [0.29.1] 2024-07-25
 ### Fixed
 - Fixed the prometheus metrics cant cast metric type gauge to info issue.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.29.1
+version=0.30.0

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSender.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TransactionalKafkaMessageSender.java
@@ -147,10 +147,10 @@ public class TransactionalKafkaMessageSender implements ITransactionalKafkaMessa
 
   @Override
   public SendMessagesResult sendMessages(SendMessagesRequest request) {
-    var transactionActive = TransactionSynchronizationManager.isActualTransactionActive();
     request.getTkmsMessages().forEach(message -> messageDecorators.forEach(message::accept));
     validateMessages(request);
 
+    var transactionActive = TransactionSynchronizationManager.isActualTransactionActive();
     var validatedTopics = new HashSet<String>();
 
     int seq = 0;

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/ITkmsMessageDecorator.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/ITkmsMessageDecorator.java
@@ -2,10 +2,20 @@ package com.transferwise.kafka.tkms.api;
 
 import com.transferwise.kafka.tkms.api.TkmsMessage.Header;
 import java.util.List;
+import org.springframework.core.Ordered;
 
-public interface ITkmsMessageDecorator {
+public interface ITkmsMessageDecorator extends Ordered {
 
-  default List<Header> getHeaders(TkmsMessage message) {
+  default List<Header> getAdditionalHeaders(TkmsMessage message) {
     return List.of();
   }
+
+  default TkmsShardPartition getOverridedPartition(TkmsMessage message) {
+    return null;
+  }
+
+  default int getOrder() {
+    return LOWEST_PRECEDENCE;
+  }
+
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/ITkmsMessageDecorator.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/ITkmsMessageDecorator.java
@@ -2,10 +2,10 @@ package com.transferwise.kafka.tkms.api;
 
 import com.transferwise.kafka.tkms.api.TkmsMessage.Header;
 import java.util.List;
-import java.util.Map;
 
 public interface ITkmsMessageDecorator {
-  default List<Header> getHeaders(TkmsMessage message){
+
+  default List<Header> getHeaders(TkmsMessage message) {
     return List.of();
   }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/ITkmsMessageDecorator.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/ITkmsMessageDecorator.java
@@ -1,0 +1,11 @@
+package com.transferwise.kafka.tkms.api;
+
+import com.transferwise.kafka.tkms.api.TkmsMessage.Header;
+import java.util.List;
+import java.util.Map;
+
+public interface ITkmsMessageDecorator {
+  default List<Header> getHeaders(TkmsMessage message){
+    return List.of();
+  }
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/TkmsMessage.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/TkmsMessage.java
@@ -79,9 +79,9 @@ public class TkmsMessage {
     return this;
   }
 
-  public TkmsMessage accept(ITkmsMessageDecorator decorator){
+  public TkmsMessage accept(ITkmsMessageDecorator decorator) {
     var headers = decorator.getHeaders(this);
-    if(headers != null){
+    if (headers != null) {
       headers.forEach(this::addHeader);
     }
     return this;

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/TkmsMessage.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/TkmsMessage.java
@@ -80,9 +80,14 @@ public class TkmsMessage {
   }
 
   public TkmsMessage accept(ITkmsMessageDecorator decorator) {
-    var headers = decorator.getHeaders(this);
+    var headers = decorator.getAdditionalHeaders(this);
     if (headers != null) {
       headers.forEach(this::addHeader);
+    }
+    var overridedPartition = decorator.getOverridedPartition(this);
+    if (overridedPartition != null) {
+      setShard(overridedPartition.getShard());
+      setPartition(overridedPartition.getPartition());
     }
     return this;
   }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/TkmsMessage.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/TkmsMessage.java
@@ -79,6 +79,14 @@ public class TkmsMessage {
     return this;
   }
 
+  public TkmsMessage accept(ITkmsMessageDecorator decorator){
+    var headers = decorator.getHeaders(this);
+    if(headers != null){
+      headers.forEach(this::addHeader);
+    }
+    return this;
+  }
+
   /**
    * Forces specified compression.
    */

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/TkmsShardPartition.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/api/TkmsShardPartition.java
@@ -17,7 +17,7 @@ public class TkmsShardPartition {
   private Tag micrometerPartitionTag;
   private String stringPresentation;
 
-  private TkmsShardPartition(int shard, int partition) {
+  public TkmsShardPartition(int shard, int partition) {
     this.shard = shard;
     this.partition = partition;
     this.micrometerShardTag = Tag.of("shard", String.valueOf(shard));

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsAutoConfiguration.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsAutoConfiguration.java
@@ -42,7 +42,7 @@ public class TkmsAutoConfiguration {
   public TransactionsHelper twTransactionsHelper() {
     return new TransactionsHelper();
   }
-  
+
   @Bean
   @ConditionalOnMissingBean(ITkmsMessageDecorator.class)
   public List<ITkmsMessageDecorator> messageDecorators() {

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsAutoConfiguration.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsAutoConfiguration.java
@@ -8,6 +8,8 @@ import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHel
 import com.transferwise.common.baseutils.transactionsmanagement.TransactionsHelper;
 import com.transferwise.kafka.tkms.api.ITkmsMessageDecorator;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Collections;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -16,8 +18,6 @@ import org.springframework.boot.autoconfigure.validation.ValidationAutoConfigura
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import java.util.Collections;
-import java.util.List;
 
 @Configuration
 @AutoConfigureAfter({FlywayAutoConfiguration.class, ValidationAutoConfiguration.class})
@@ -42,7 +42,7 @@ public class TkmsAutoConfiguration {
   public TransactionsHelper twTransactionsHelper() {
     return new TransactionsHelper();
   }
-
+  
   @Bean
   @ConditionalOnMissingBean(ITkmsMessageDecorator.class)
   public List<ITkmsMessageDecorator> messageDecorators() {

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsAutoConfiguration.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsAutoConfiguration.java
@@ -44,7 +44,7 @@ public class TkmsAutoConfiguration {
   }
 
   @Bean
-  @ConditionalOnMissingBean
+  @ConditionalOnMissingBean(ITkmsMessageDecorator.class)
   public List<ITkmsMessageDecorator> messageDecorators() {
     return Collections.emptyList();
   }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsAutoConfiguration.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsAutoConfiguration.java
@@ -6,6 +6,7 @@ import com.transferwise.common.baseutils.meters.cache.IMeterCache;
 import com.transferwise.common.baseutils.meters.cache.MeterCache;
 import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHelper;
 import com.transferwise.common.baseutils.transactionsmanagement.TransactionsHelper;
+import com.transferwise.kafka.tkms.api.ITkmsMessageDecorator;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -15,6 +16,8 @@ import org.springframework.boot.autoconfigure.validation.ValidationAutoConfigura
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import java.util.Collections;
+import java.util.List;
 
 @Configuration
 @AutoConfigureAfter({FlywayAutoConfiguration.class, ValidationAutoConfiguration.class})
@@ -38,6 +41,12 @@ public class TkmsAutoConfiguration {
   @ConditionalOnMissingBean(ITransactionsHelper.class)
   public TransactionsHelper twTransactionsHelper() {
     return new TransactionsHelper();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public List<ITkmsMessageDecorator> messageDecorators() {
+    return Collections.emptyList();
   }
 
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MessageDecorationTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MessageDecorationTest.java
@@ -43,8 +43,8 @@ class MessageDecorationTest extends BaseIntTest {
 
     transactionsHelper.withTransaction().run(() ->
         transactionalKafkaMessageSender.sendMessages(new SendMessagesRequest()
-            .addTkmsMessage(new TkmsMessage().setTopic(topic).setKey("adam-jones").setValue(someValue))
-            .addTkmsMessage(new TkmsMessage().setTopic(topic).setKey("danny-carey").setValue(someValue))
+            .addTkmsMessage(new TkmsMessage().setTopic(topic).setKey("adam-jones").setShard(4).setValue(someValue))
+            .addTkmsMessage(new TkmsMessage().setTopic(topic).setKey("danny-carey").setPartition(5).setValue(someValue))
         ));
 
     await().until(() -> tkmsSentMessagesCollector.getSentMessages(topic).size() == 2);
@@ -52,7 +52,11 @@ class MessageDecorationTest extends BaseIntTest {
 
     assertEquals(2, messages.size());
     checkForHeader(messages.get(0), "tool", "jambi");
+    assertEquals(0, messages.get(0).getShardPartition().getShard());
+    assertEquals(0, messages.get(0).getShardPartition().getPartition());
     checkForHeader(messages.get(1), "tool", "jambi");
+    assertEquals(0, messages.get(1).getShardPartition().getShard());
+    assertEquals(0, messages.get(1).getShardPartition().getPartition());
   }
 
   private void checkForHeader(SentMessage sentMessage, String key, String value) {

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MessageDecorationTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MessageDecorationTest.java
@@ -1,28 +1,22 @@
 package com.transferwise.kafka.tkms;
 
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHelper;
-import com.transferwise.kafka.tkms.api.ITkmsMessageInterceptor.MessageInterceptionDecision;
 import com.transferwise.kafka.tkms.api.ITransactionalKafkaMessageSender.SendMessagesRequest;
 import com.transferwise.kafka.tkms.api.TkmsMessage;
 import com.transferwise.kafka.tkms.test.BaseIntTest;
 import com.transferwise.kafka.tkms.test.ITkmsSentMessagesCollector.SentMessage;
 import com.transferwise.kafka.tkms.test.TestMessagesInterceptor;
 import com.transferwise.kafka.tkms.test.TestProperties;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 class MessageDecorationTest extends BaseIntTest {
@@ -49,22 +43,22 @@ class MessageDecorationTest extends BaseIntTest {
 
     transactionsHelper.withTransaction().run(() ->
         transactionalKafkaMessageSender.sendMessages(new SendMessagesRequest()
-            .addTkmsMessage(new TkmsMessage().setTopic(topic).setKey("A").setValue(someValue))
-            .addTkmsMessage(new TkmsMessage().setTopic(topic).setKey("B").setValue(someValue))
+            .addTkmsMessage(new TkmsMessage().setTopic(topic).setKey("adam-jones").setValue(someValue))
+            .addTkmsMessage(new TkmsMessage().setTopic(topic).setKey("danny-carey").setValue(someValue))
         ));
 
     await().until(() -> tkmsSentMessagesCollector.getSentMessages(topic).size() == 2);
-
     var messages = tkmsSentMessagesCollector.getSentMessages(topic);
-    assertThat(messages.size()).isEqualTo(2);
-    checkForHeader(messages.get(0) , "adam-jones" , "jambi");
-    checkForHeader(messages.get(1) , "danny-carey" , "the-grudge");
+
+    assertEquals(2, messages.size());
+    checkForHeader(messages.get(0), "tool", "jambi");
+    checkForHeader(messages.get(1), "tool", "jambi");
   }
 
   private void checkForHeader(SentMessage sentMessage, String key, String value) {
     assertTrue(
-        StreamSupport.stream(sentMessage.getProducerRecord().headers().spliterator() , false)
-        .anyMatch(h -> h.key().equals(key) && value.equals(new String(h.value())))
+        StreamSupport.stream(sentMessage.getProducerRecord().headers().spliterator(), false)
+            .anyMatch(h -> h.key().equals(key) && value.equals(new String(h.value())))
     );
   }
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MessageDecorationTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MessageDecorationTest.java
@@ -58,7 +58,7 @@ class MessageDecorationTest extends BaseIntTest {
   private void checkForHeader(SentMessage sentMessage, String key, String value) {
     assertTrue(
         StreamSupport.stream(sentMessage.getProducerRecord().headers().spliterator(), false)
-            .anyMatch(h -> h.key().equals(key) && value.equals(new String(h.value())))
+            .anyMatch(h -> h.key().equals(key) && value.equals(new String(h.value(), StandardCharsets.UTF_8)))
     );
   }
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MessageDecorationTest.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/MessageDecorationTest.java
@@ -1,0 +1,70 @@
+package com.transferwise.kafka.tkms;
+
+import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHelper;
+import com.transferwise.kafka.tkms.api.ITkmsMessageInterceptor.MessageInterceptionDecision;
+import com.transferwise.kafka.tkms.api.ITransactionalKafkaMessageSender.SendMessagesRequest;
+import com.transferwise.kafka.tkms.api.TkmsMessage;
+import com.transferwise.kafka.tkms.test.BaseIntTest;
+import com.transferwise.kafka.tkms.test.ITkmsSentMessagesCollector.SentMessage;
+import com.transferwise.kafka.tkms.test.TestMessagesInterceptor;
+import com.transferwise.kafka.tkms.test.TestProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Slf4j
+class MessageDecorationTest extends BaseIntTest {
+
+  @Autowired
+  private TestMessagesInterceptor testMessagesInterceptor;
+  @Autowired
+  private TransactionalKafkaMessageSender transactionalKafkaMessageSender;
+  @Autowired
+  private TestProperties testProperties;
+  @Autowired
+  private ITransactionsHelper transactionsHelper;
+
+  @AfterEach
+  void cleanupTest() {
+    testMessagesInterceptor.setBeforeSendingToKafkaFunction(null);
+  }
+
+  @Test
+  void messagesAreDecorateWithJambi() {
+    byte[] someValue = "Here from the king's mountain view, Feast like a sultan I do!".getBytes(StandardCharsets.UTF_8);
+
+    String topic = testProperties.getTestTopic();
+
+    transactionsHelper.withTransaction().run(() ->
+        transactionalKafkaMessageSender.sendMessages(new SendMessagesRequest()
+            .addTkmsMessage(new TkmsMessage().setTopic(topic).setKey("A").setValue(someValue))
+            .addTkmsMessage(new TkmsMessage().setTopic(topic).setKey("B").setValue(someValue))
+        ));
+
+    await().until(() -> tkmsSentMessagesCollector.getSentMessages(topic).size() == 2);
+
+    var messages = tkmsSentMessagesCollector.getSentMessages(topic);
+    assertThat(messages.size()).isEqualTo(2);
+    checkForHeader(messages.get(0) , "adam-jones" , "jambi");
+    checkForHeader(messages.get(1) , "danny-carey" , "the-grudge");
+  }
+
+  private void checkForHeader(SentMessage sentMessage, String key, String value) {
+    assertTrue(
+        StreamSupport.stream(sentMessage.getProducerRecord().headers().spliterator() , false)
+        .anyMatch(h -> h.key().equals(key) && value.equals(new String(h.value())))
+    );
+  }
+}

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestMessageDecorator.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestMessageDecorator.java
@@ -1,0 +1,21 @@
+package com.transferwise.kafka.tkms.test;
+
+import com.transferwise.kafka.tkms.api.ITkmsMessageDecorator;
+import com.transferwise.kafka.tkms.api.TkmsMessage;
+import com.transferwise.kafka.tkms.api.TkmsMessage.Header;
+import org.springframework.stereotype.Component;
+import java.util.List;
+
+@Component
+public class TestMessageDecorator implements ITkmsMessageDecorator {
+
+  @Override
+  public List<Header> getHeaders(TkmsMessage message){
+    var h1 = new Header().setKey("adam-jones").setValue("jambi".getBytes());
+    if (message.getValue() != null && new String(message.getValue()).startsWith("Here from the king")) {
+      return List.of(h1);
+    }
+    return List.of();
+  }
+
+}

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestMessageDecorator.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestMessageDecorator.java
@@ -13,16 +13,18 @@ public class TestMessageDecorator implements ITkmsMessageDecorator {
 
   @Override
   public List<Header> getAdditionalHeaders(TkmsMessage message) {
-    var h1 = new Header().setKey("tool").setValue("jambi".getBytes(StandardCharsets.UTF_8));
     if (message.getValue() != null && new String(message.getValue(), StandardCharsets.UTF_8).startsWith("Here from")) {
-      return List.of(h1);
+      return List.of(new Header().setKey("tool").setValue("jambi".getBytes(StandardCharsets.UTF_8)));
     }
     return List.of();
   }
 
   @Override
   public TkmsShardPartition getOverridedPartition(TkmsMessage message) {
-    return new TkmsShardPartition(0, 0);
+    if (message.getValue() != null && new String(message.getValue(), StandardCharsets.UTF_8).startsWith("Here from")) {
+      return new TkmsShardPartition(0, 0);
+    }
+    return new TkmsShardPartition(message.getShard(), message.getPartition());
   }
 
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestMessageDecorator.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestMessageDecorator.java
@@ -3,6 +3,7 @@ package com.transferwise.kafka.tkms.test;
 import com.transferwise.kafka.tkms.api.ITkmsMessageDecorator;
 import com.transferwise.kafka.tkms.api.TkmsMessage;
 import com.transferwise.kafka.tkms.api.TkmsMessage.Header;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +12,7 @@ public class TestMessageDecorator implements ITkmsMessageDecorator {
 
   @Override
   public List<Header> getHeaders(TkmsMessage message) {
-    var h1 = new Header().setKey("tool").setValue("jambi".getBytes());
+    var h1 = new Header().setKey("tool").setValue("jambi".getBytes(StandardCharsets.UTF_8));
     if (message.getKey() == null) {
       return List.of();
     }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestMessageDecorator.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestMessageDecorator.java
@@ -3,6 +3,7 @@ package com.transferwise.kafka.tkms.test;
 import com.transferwise.kafka.tkms.api.ITkmsMessageDecorator;
 import com.transferwise.kafka.tkms.api.TkmsMessage;
 import com.transferwise.kafka.tkms.api.TkmsMessage.Header;
+import com.transferwise.kafka.tkms.api.TkmsShardPartition;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.springframework.stereotype.Component;
@@ -11,12 +12,17 @@ import org.springframework.stereotype.Component;
 public class TestMessageDecorator implements ITkmsMessageDecorator {
 
   @Override
-  public List<Header> getHeaders(TkmsMessage message) {
+  public List<Header> getAdditionalHeaders(TkmsMessage message) {
     var h1 = new Header().setKey("tool").setValue("jambi".getBytes(StandardCharsets.UTF_8));
     if (message.getValue() != null && new String(message.getValue(), StandardCharsets.UTF_8).startsWith("Here from")) {
       return List.of(h1);
     }
     return List.of();
+  }
+
+  @Override
+  public TkmsShardPartition getOverridedPartition(TkmsMessage message) {
+    return new TkmsShardPartition(0, 0);
   }
 
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestMessageDecorator.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestMessageDecorator.java
@@ -13,10 +13,10 @@ public class TestMessageDecorator implements ITkmsMessageDecorator {
   @Override
   public List<Header> getHeaders(TkmsMessage message) {
     var h1 = new Header().setKey("tool").setValue("jambi".getBytes(StandardCharsets.UTF_8));
-    if (message.getKey() == null) {
-      return List.of();
+    if (message.getValue() != null && new String(message.getValue(), StandardCharsets.UTF_8).startsWith("Here from")) {
+      return List.of(h1);
     }
-    return List.of(h1);
+    return List.of();
   }
 
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestMessageDecorator.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestMessageDecorator.java
@@ -24,7 +24,7 @@ public class TestMessageDecorator implements ITkmsMessageDecorator {
     if (message.getValue() != null && new String(message.getValue(), StandardCharsets.UTF_8).startsWith("Here from")) {
       return new TkmsShardPartition(0, 0);
     }
-    return new TkmsShardPartition(message.getShard(), message.getPartition());
+    return null;
   }
 
 }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestMessageDecorator.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/test/TestMessageDecorator.java
@@ -3,19 +3,19 @@ package com.transferwise.kafka.tkms.test;
 import com.transferwise.kafka.tkms.api.ITkmsMessageDecorator;
 import com.transferwise.kafka.tkms.api.TkmsMessage;
 import com.transferwise.kafka.tkms.api.TkmsMessage.Header;
-import org.springframework.stereotype.Component;
 import java.util.List;
+import org.springframework.stereotype.Component;
 
 @Component
 public class TestMessageDecorator implements ITkmsMessageDecorator {
 
   @Override
-  public List<Header> getHeaders(TkmsMessage message){
-    var h1 = new Header().setKey("adam-jones").setValue("jambi".getBytes());
-    if (message.getValue() != null && new String(message.getValue()).startsWith("Here from the king")) {
-      return List.of(h1);
+  public List<Header> getHeaders(TkmsMessage message) {
+    var h1 = new Header().setKey("tool").setValue("jambi".getBytes());
+    if (message.getKey() == null) {
+      return List.of();
     }
-    return List.of();
+    return List.of(h1);
   }
 
 }


### PR DESCRIPTION
## Context

Adding a decorator interface that services can write their headers injectors separately
To be used with cases like transfers where we want to add transfer headers in the whole service
So instead of modifying every message, you can write a single decorator 


## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
