### PR TITLE
[APPENG-927] Yield MetricFilter's as Beans for Spring to apply to MeterRegistry via post processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.1] - 2024-08-08
+### Changed
+- MeterFilter's applied by the library are no longer explicitly applied and are instead
+
 ## [0.30.0] 2024-08-06
 ### Added
 - Added `ITkmsMessageDecorator` that kicks in before message is registered and adds custom headers

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.30.0
+version=0.30.1

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsAutoConfiguration.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsAutoConfiguration.java
@@ -37,6 +37,8 @@ public class TkmsAutoConfiguration {
     return new MeterCache(meterRegistry);
   }
 
+
+
   @Bean
   @ConditionalOnMissingBean(ITransactionsHelper.class)
   public TransactionsHelper twTransactionsHelper() {

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/metrics/TkmsMetricsTemplate.java
@@ -81,41 +81,7 @@ public class TkmsMetricsTemplate implements ITkmsMetricsTemplate, InitializingBe
 
   @Override
   public void afterPropertiesSet() {
-    Map<String, double[]> slos = new HashMap<>();
-    double[] defaultSlos = new double[]{1, 5, 25, 125, 625, 3125, 15625};
-    slos.put(TIMER_PROXY_POLL, defaultSlos);
-    slos.put(TIMER_PROXY_CYCLE, defaultSlos);
-    slos.put(TIMER_PROXY_CYCLE_PAUSE, defaultSlos);
-    slos.put(TIMER_DAO_POLL_FIRST_RESULT, defaultSlos);
-    slos.put(TIMRE_DAO_POLL_ALL_RESULTS, defaultSlos);
-    slos.put(TIMER_DAO_POLL_GET_CONNECTION, defaultSlos);
-    slos.put(TIMER_PROXY_KAFKA_MESSAGES_SEND, defaultSlos);
-    slos.put(TIMER_PROXY_MESSAGES_DELETION, defaultSlos);
-    slos.put(SUMMARY_DAO_POLL_ALL_RESULTS_COUNT, defaultSlos);
-    slos.put(TIMER_MESSAGE_INSERT_TO_ACK, new double[]{1, 5, 25, 125, 625, 3125, 15625});
-    slos.put(SUMMARY_DAO_COMPRESSION_RATIO_ACHIEVED, new double[]{0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.25, 2, 4});
-    slos.put(SUMMARY_MESSAGES_IN_TRANSACTION, new double[]{1, 5, 25, 125, 625, 3125, 15625, 5 * 15625});
 
-    meterCache.getMeterRegistry().config().meterFilter(new MeterFilter() {
-      @Override
-      public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
-        double[] sloConfigValues = slos.get(id.getName());
-        if (sloConfigValues != null) {
-          double[] sloValues = Arrays.copyOf(sloConfigValues, sloConfigValues.length);
-          if (id.getType() == Type.TIMER) {
-            for (int i = 0; i < sloValues.length; i++) {
-              sloValues[i] = sloValues[i] * 1_000_000L;
-            }
-          }
-          return DistributionStatisticConfig.builder()
-              .percentilesHistogram(false)
-              .serviceLevelObjectives(sloValues)
-              .build()
-              .merge(config);
-        }
-        return config;
-      }
-    });
   }
 
   @Override


### PR DESCRIPTION
## Context

A PR to micrometer (https://github.com/micrometer-metrics/micrometer/pull/4917) added a log message to warn that MeterFilter's have been applied to MeterRegistry after meters have been registered with it.

This library is an offender. This PR no longer explicitly applied MeterFilter's itself and insteads yields them as Beans for Spring to pass to MeterRegistryPostProcessor which will apply them.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 


## Details from ticket: [APPENG-927](https://transferwise.atlassian.net/browse/APPENG-927)

### Stop explicitly applying MeterFilter's in all platform libraries

>Context in Slack thread: [https://wise.slack.com/archives/C0437QJBY4V/p1722955739049859|https://wise.slack.com/archives/C0437QJBY4V/p1722955739049859|smart-link] 
>
>We should go over our platform libraries and ensure that we don’t explicitly apply MeterFilter’s to MeterRegistry. Instead we should created the MeterFilter’s and expose them to Spring as Bean’s so that {{MeterRegistryPostProcessor}} can apply them correctly for us.
>
>Known offenders are:
>
>* tw-entrypoints - done
>* tw-service-comms
>* tw-tkms
>* wise-kafka-processor


[APPENG-927]: https://transferwise.atlassian.net/browse/APPENG-927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ