### PR TITLE
Deferred messages are enabled by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.0] - 2024-10-28
+
+### Changed
+
+- Messages are now deferred up to pre-commit hook by default.
+  This allows better database resource usage in most cases.
+
 ## [0.32.0] - 2024-10-11
 ### Added
 - Added a postprocessor to the `TkmsKafkaProducerProvider` to allow features like tracing attached to the Kafka Producer.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.32.0
+version=0.33.0

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -233,10 +233,8 @@ public class TkmsProperties implements InitializingBean {
    *
    * <p>The tradeoff is that higher application memory is required for transactions sending out huge number or/and huge messages.
    * However, in practical applications, large transactions should be avoided anyway.
-   *
-   * <p>May default to true for Postgres in upcoming versions. Or even default to true in all situations.
    */
-  private boolean deferMessageRegistrationUntilCommit = false;
+  private boolean deferMessageRegistrationUntilCommit = true;
 
   @Valid
   @jakarta.validation.Valid

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
@@ -52,7 +52,7 @@ public class TkmsMariaDao extends TkmsDao {
         boolean engineIndependentStatsEnabled = isEngineIndependentStatsEnabled();
         if (!engineIndependentStatsEnabled) {
           problemNotifier.notify(null, NotificationType.ENGINE_INDEPENDENT_STATS_NOT_ENABLED, NotificationLevel.WARN, () ->
-              "Engine independent statics are not enabled.");
+              "Engine independent statistics are not enabled.");
         }
       } catch (DataAccessException dae) {
         problemNotifier.notify(null, NotificationType.TABLE_INDEX_STATS_CHECK_ERROR, NotificationLevel.ERROR, () ->


### PR DESCRIPTION
## Context

### Changed

- Messages are now deferred up to pre-commit hook by default.
  This allows better database resource usage in most cases.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
