### PR TITLE
Add parallelism to message pooling process

### DIFF
--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/ITkmsMessagePoller.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/ITkmsMessagePoller.java
@@ -1,0 +1,11 @@
+package com.transferwise.kafka.tkms;
+
+import com.transferwise.kafka.tkms.api.TkmsShardPartition;
+import com.transferwise.kafka.tkms.dao.ITkmsDao.MessageRecord;
+import java.util.List;
+
+public interface ITkmsMessagePoller {
+
+  List<MessageRecord> pullMessages(TkmsShardPartition shardPartition, long earliestMessageId, int batchSize);
+
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/ITkmsMessagePollerFactory.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/ITkmsMessagePollerFactory.java
@@ -1,0 +1,8 @@
+package com.transferwise.kafka.tkms;
+
+
+public interface ITkmsMessagePollerFactory {
+
+  ITkmsMessagePoller createPoller(int shard);
+
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsMessagePoller.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsMessagePoller.java
@@ -14,7 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 
 
 @Slf4j
-public class TkmsMessagePoller {
+public class TkmsMessagePoller implements ITkmsMessagePoller {
 
   private final ITkmsDaoProvider tkmsDaoProvider;
   private final IExecutorServicesProvider executorServicesProvider;
@@ -29,6 +29,7 @@ public class TkmsMessagePoller {
     this.useExecutors = pollerParallelism > 1;
   }
 
+  @Override
   public List<MessageRecord> pullMessages(
       TkmsShardPartition shardPartition,
       long earliestMessageId,

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsMessagePoller.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsMessagePoller.java
@@ -14,7 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 
 
 @Slf4j
-public class TkmsMessagePooler {
+public class TkmsMessagePoller {
 
   private final ITkmsDaoProvider tkmsDaoProvider;
   private final IExecutorServicesProvider executorServicesProvider;
@@ -22,7 +22,7 @@ public class TkmsMessagePooler {
 
   boolean useExecutors;
 
-  public TkmsMessagePooler(ITkmsDaoProvider tkmsDaoProvider, IExecutorServicesProvider executorServicesProvider, int pollerParallelism) {
+  public TkmsMessagePoller(ITkmsDaoProvider tkmsDaoProvider, IExecutorServicesProvider executorServicesProvider, int pollerParallelism) {
     this.tkmsDaoProvider = tkmsDaoProvider;
     this.executorServicesProvider = executorServicesProvider;
     this.pollerParallelism = pollerParallelism;

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsMessagePoller.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsMessagePoller.java
@@ -20,7 +20,7 @@ public class TkmsMessagePoller {
   private final IExecutorServicesProvider executorServicesProvider;
   private final int pollerParallelism;
 
-  boolean useExecutors;
+  private boolean useExecutors;
 
   public TkmsMessagePoller(ITkmsDaoProvider tkmsDaoProvider, IExecutorServicesProvider executorServicesProvider, int pollerParallelism) {
     this.tkmsDaoProvider = tkmsDaoProvider;

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsMessagePoller.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsMessagePoller.java
@@ -70,8 +70,7 @@ public class TkmsMessagePoller {
       futures.add(CompletableFuture.supplyAsync(
           () -> tkmsDao.getMessages(shardPartition, minId, limit, offset),
           executorServicesProvider.getGlobalExecutorService()));
-      long lastLimit =  minId + (long) (i + 1) * batchSize;
-      if (lastLimit > maxId) {
+      if (minId + offset + limit > maxId) {
         break;
       }
     }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsMessagePollerFactory.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsMessagePollerFactory.java
@@ -1,0 +1,22 @@
+package com.transferwise.kafka.tkms;
+
+import com.transferwise.common.baseutils.concurrency.IExecutorServicesProvider;
+import com.transferwise.kafka.tkms.config.ITkmsDaoProvider;
+import com.transferwise.kafka.tkms.config.TkmsProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class TkmsMessagePollerFactory implements ITkmsMessagePollerFactory {
+
+  @Autowired
+  private ITkmsDaoProvider tkmsDaoProvider;
+  @Autowired
+  private IExecutorServicesProvider executorServicesProvider;
+  @Autowired
+  private TkmsProperties properties;
+
+  @Override
+  public TkmsMessagePoller createPoller(int shard) {
+    int pollerParallelism = properties.getPollerParallelism(shard);
+    return new TkmsMessagePoller(tkmsDaoProvider, executorServicesProvider, pollerParallelism);
+  }
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsMessagePooler.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsMessagePooler.java
@@ -1,0 +1,73 @@
+package com.transferwise.kafka.tkms;
+
+import com.transferwise.common.baseutils.concurrency.IExecutorServicesProvider;
+import com.transferwise.kafka.tkms.api.TkmsShardPartition;
+import com.transferwise.kafka.tkms.config.ITkmsDaoProvider;
+import com.transferwise.kafka.tkms.dao.ITkmsDao;
+import com.transferwise.kafka.tkms.dao.ITkmsDao.MessageRecord;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+public class TkmsMessagePooler {
+
+  private final ITkmsDaoProvider tkmsDaoProvider;
+  private final IExecutorServicesProvider executorServicesProvider;
+
+  public TkmsMessagePooler(ITkmsDaoProvider tkmsDaoProvider, IExecutorServicesProvider executorServicesProvider) {
+    this.tkmsDaoProvider = tkmsDaoProvider;
+    this.executorServicesProvider = executorServicesProvider;
+  }
+
+  public List<MessageRecord> pullMessages(
+      TkmsShardPartition shardPartition,
+      long earliestMessageId,
+      int batchSize, int parallelism) {
+
+    if (parallelism > 1) {
+      return pullMessagesParallel(shardPartition, earliestMessageId, batchSize, parallelism);
+    } else {
+      return pullMessagesSequential(shardPartition, earliestMessageId, batchSize);
+    }
+  }
+
+  private List<MessageRecord> pullMessagesSequential(
+      TkmsShardPartition shardPartition,
+      long earliestMessageId,
+      int batchSize) {
+
+    ITkmsDao tkmsDao = tkmsDaoProvider.getTkmsDao(shardPartition.getShard());
+    return tkmsDao.getMessages(shardPartition, earliestMessageId, batchSize);
+  }
+
+  private List<MessageRecord> pullMessagesParallel(
+      TkmsShardPartition shardPartition,
+      long earliestMessageId,
+      int batchSize,
+      int parallelism) {
+
+    ITkmsDao tkmsDao = tkmsDaoProvider.getTkmsDao(shardPartition.getShard());
+
+    List<CompletableFuture<List<MessageRecord>>> futures = new ArrayList<>();
+    for (int i = 0; i < parallelism; i++) {
+      final int offset = i * batchSize;
+      final int limit = batchSize;
+
+      futures.add(CompletableFuture.supplyAsync(
+          () -> tkmsDao.getMessages(shardPartition, earliestMessageId, limit, offset),
+          executorServicesProvider.getGlobalExecutorService()));
+    }
+
+    List<MessageRecord> allRecords = new ArrayList<>();
+    for (CompletableFuture<List<MessageRecord>> future : futures) {
+      allRecords.addAll(future.join());
+    }
+
+    return allRecords.stream().sorted(Comparator.comparing(MessageRecord::getId)).collect(Collectors.toList());
+  }
+}

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsStorageToKafkaProxy.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsStorageToKafkaProxy.java
@@ -187,7 +187,7 @@ public class TkmsStorageToKafkaProxy implements GracefulShutdownStrategy, ITkmsS
       pollAllInterval = null;
     }
 
-    TkmsMessagePooler messagePooler = new TkmsMessagePooler(tkmsDaoProvider, executorServicesProvider,
+    TkmsMessagePoller messagePooler = new TkmsMessagePoller(tkmsDaoProvider, executorServicesProvider,
         properties.getPollerParallelism(shardPartition.getShard()));
 
     try {

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsStorageToKafkaProxy.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/TkmsStorageToKafkaProxy.java
@@ -82,6 +82,8 @@ public class TkmsStorageToKafkaProxy implements GracefulShutdownStrategy, ITkmsS
   private SharedReentrantLockBuilderFactory lockBuilderFactory;
   @Autowired
   private ITkmsInterrupterService tkmsInterrupterService;
+  @Autowired
+  private ITkmsMessagePollerFactory messagePollerFactory;
 
   @TestOnly
   private volatile boolean paused = false;
@@ -187,8 +189,7 @@ public class TkmsStorageToKafkaProxy implements GracefulShutdownStrategy, ITkmsS
       pollAllInterval = null;
     }
 
-    TkmsMessagePoller messagePooler = new TkmsMessagePoller(tkmsDaoProvider, executorServicesProvider,
-        properties.getPollerParallelism(shardPartition.getShard()));
+    ITkmsMessagePoller messagePooler = messagePollerFactory.createPoller(shardPartition.getShard());
 
     try {
       MutableObject<Duration> proxyCyclePauseRequest = new MutableObject<>();

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsConfiguration.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsConfiguration.java
@@ -5,6 +5,7 @@ import com.transferwise.kafka.tkms.EnvironmentValidator;
 import com.transferwise.kafka.tkms.IEnvironmentValidator;
 import com.transferwise.kafka.tkms.IProblemNotifier;
 import com.transferwise.kafka.tkms.ITkmsInterrupterService;
+import com.transferwise.kafka.tkms.ITkmsMessagePollerFactory;
 import com.transferwise.kafka.tkms.ITkmsPaceMaker;
 import com.transferwise.kafka.tkms.ITkmsStorageToKafkaProxy;
 import com.transferwise.kafka.tkms.ITkmsTopicValidator;
@@ -13,6 +14,7 @@ import com.transferwise.kafka.tkms.JavaxValidationEnvironmentValidator;
 import com.transferwise.kafka.tkms.ProblemNotifier;
 import com.transferwise.kafka.tkms.TkmsInterrupterService;
 import com.transferwise.kafka.tkms.TkmsMessageInterceptors;
+import com.transferwise.kafka.tkms.TkmsMessagePollerFactory;
 import com.transferwise.kafka.tkms.TkmsPaceMaker;
 import com.transferwise.kafka.tkms.TkmsStorageToKafkaProxy;
 import com.transferwise.kafka.tkms.TkmsTopicValidator;
@@ -238,5 +240,11 @@ public class TkmsConfiguration {
   @ConditionalOnMissingBean(ITkmsTopicValidator.class)
   public ITkmsTopicValidator tkmsTopicValidator() {
     return new TkmsTopicValidator();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ITkmsMessagePollerFactory.class)
+  public ITkmsMessagePollerFactory tkmsMessagePollerFactory() {
+    return new TkmsMessagePollerFactory();
   }
 }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/config/TkmsProperties.java
@@ -102,6 +102,17 @@ public class TkmsProperties implements InitializingBean {
   private int pollerBatchSize = 1024;
 
   /**
+   * Number of parallel threads to use for pulling messages from the database.
+   *
+   * <p>Default is 1 (sequential). Increase to improve throughput when database can handle concurrent queries.
+   *
+   * <p>Each thread will pull up to pollerBatchSize messages, so total messages per poll cycle = pollerBatchSize * pollerParallelism.
+   */
+  @Positive
+  @jakarta.validation.constraints.Positive
+  private int pollerParallelism = 1;
+
+  /**
    * Specifies the parameters counts used when executing messages deletions queries, right after successfully sending batch of messages out.
    *
    * <p>You may want/need to reduce the maximum batch sizes, in the case your database tries to execute queries in a very inefficent way. E.g. doing
@@ -296,6 +307,7 @@ public class TkmsProperties implements InitializingBean {
     private DatabaseDialect databaseDialect;
     private Integer partitionsCount;
     private Integer pollerBatchSize;
+    private Integer pollerParallelism;
     private Duration pollingInterval;
     private Duration pauseTimeOnErrors;
     private Integer insertBatchSize;
@@ -367,6 +379,14 @@ public class TkmsProperties implements InitializingBean {
       return shardProperties.getPollerBatchSize();
     }
     return pollerBatchSize;
+  }
+
+  public int getPollerParallelism(int shard) {
+    var shardProperties = shards.get(shard);
+    if (shardProperties != null && shardProperties.getPollerParallelism() != null) {
+      return shardProperties.getPollerParallelism();
+    }
+    return pollerParallelism;
   }
 
   public Duration getPollingInterval(int shard) {

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/ITkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/ITkmsDao.java
@@ -60,6 +60,22 @@ public interface ITkmsDao {
   boolean insertEarliestMessageId(TkmsShardPartition shardPartition);
 
   /**
+   * Returns the minimum message ID from the outbox table.
+   *
+   * @param shardPartition the shard partition to query
+   * @return the minimum message ID
+   */
+  Long getMinMessageId(TkmsShardPartition shardPartition);
+
+  /**
+   * Returns the maximum message ID from the outbox table.
+   *
+   * @param shardPartition the shard partition to query
+   * @return the maximum message ID
+   */
+  Long getMaxMessageId(TkmsShardPartition shardPartition);
+
+  /**
    * Validates the database in general.
    *
    * <p>E.g. if index hints are supported.

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/ITkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/ITkmsDao.java
@@ -32,6 +32,17 @@ public interface ITkmsDao {
 
   List<MessageRecord> getMessages(TkmsShardPartition shardPartition, long earliestMessageId, int maxCount);
 
+  /**
+   * Retrieves messages using limit and offset for efficient pagination.
+   *
+   * @param shardPartition the shard partition to query
+   * @param earliestMessageId the earliest message ID to start from (-1 for all messages)
+   * @param limit the maximum number of messages to return
+   * @param offset the number of records to skip
+   * @return list of message records ordered by ID
+   */
+  List<MessageRecord> getMessages(TkmsShardPartition shardPartition, long earliestMessageId, int limit, int offset);
+
   @Data
   @Accessors(chain = true)
   class MessageRecord {

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
@@ -381,7 +381,25 @@ public abstract class TkmsDao implements ITkmsDao, InitializingBean {
     return result;
   }
 
+  @Override
+  public Long getMinMessageId(TkmsShardPartition shardPartition) {
+    var sql = sqlCache.computeIfAbsent(Pair.of(shardPartition, "getMinMessageId"), k -> getMinMessageIdSql(shardPartition));
+    List<Long> ids = jdbcTemplate.queryForList(sql, Long.class);
+    return ids.isEmpty() ? null : ids.get(0);
+  }
+
+  @Override
+  public Long getMaxMessageId(TkmsShardPartition shardPartition) {
+    var sql = sqlCache.computeIfAbsent(Pair.of(shardPartition, "getMaxMessageId"), k -> getMaxMessageIdSql(shardPartition));
+    List<Long> ids = jdbcTemplate.queryForList(sql, Long.class);
+    return ids.isEmpty() ? null : ids.get(0);
+  }
+
   protected abstract String getHasMessagesBeforeIdSql(TkmsShardPartition shardPartition);
+
+  protected abstract String getMinMessageIdSql(TkmsShardPartition shardPartition);
+
+  protected abstract String getMaxMessageIdSql(TkmsShardPartition shardPartition);
 
   protected abstract boolean doesEarliestVisibleMessagesTableExist();
 

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsDao.java
@@ -262,6 +262,59 @@ public abstract class TkmsDao implements ITkmsDao, InitializingBean {
   }
 
   @Override
+  public List<MessageRecord> getMessages(TkmsShardPartition shardPartition, long earliestMessageId, int limit, int offset) {
+    var sql = sqlCache.computeIfAbsent(Pair.of(shardPartition, "getMessagesWithOffset"), k -> getSelectWithOffsetSql(shardPartition));
+    var result = ExceptionUtils.doUnchecked(() -> {
+      long startNanoTime = System.nanoTime();
+
+      Connection con = DataSourceUtils.getConnection(dataSource);
+      try {
+        metricsTemplate.recordDaoPollGetConnection(shardPartition, startNanoTime);
+        startNanoTime = System.nanoTime();
+        int i = 0;
+
+        try (PreparedStatement ps = con.prepareStatement(sql)) {
+          ps.setLong(1, earliestMessageId);
+          ps.setLong(2, limit);
+          ps.setLong(3, offset);
+
+          List<MessageRecord> records = new ArrayList<>();
+          try (ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+              if (i++ == 0) {
+                metricsTemplate.recordDaoPollFirstResult(shardPartition, startNanoTime);
+              }
+
+              var messageId = rs.getLong(1);
+              MDC.put(properties.getMdc().getMessageIdKey(), String.valueOf(messageId));
+              try {
+                MessageRecord messageRecord = new MessageRecord();
+                messageRecord.setId(messageId);
+                messageRecord.setMessage(messageSerializer.deserialize(shardPartition, rs.getBinaryStream(2)));
+
+                records.add(messageRecord);
+              } catch (Throwable t) {
+                throw new RuntimeException(
+                    "Failed to deserialize message " + messageId + ", retrieved from table '" + getTableName(shardPartition) + "'.", t);
+              } finally {
+                MDC.remove(properties.getMdc().getMessageIdKey());
+              }
+            }
+          }
+
+          return records;
+        } finally {
+          metricsTemplate.recordDaoPollAllResults(shardPartition, i, startNanoTime);
+        }
+      } finally {
+        DataSourceUtils.releaseConnection(con, dataSource);
+      }
+    });
+
+    return result;
+  }
+
+  @Override
   public void deleteMessages(TkmsShardPartition shardPartition, List<Long> ids) {
     var batchSizeExists =
         deleteBatchSizes.computeIfAbsent(shardPartition, k -> new HashSet<>(properties.getDeleteBatchSizes(k.getShard()))).contains(ids.size());
@@ -373,6 +426,8 @@ public abstract class TkmsDao implements ITkmsDao, InitializingBean {
   protected abstract String getInsertSql(TkmsShardPartition shardPartition);
 
   protected abstract String getSelectSql(TkmsShardPartition shardPartition);
+
+  protected abstract String getSelectWithOffsetSql(TkmsShardPartition shardPartition);
 
   protected abstract String getDeleteSql(TkmsShardPartition shardPartition, int batchSize);
 

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
@@ -197,6 +197,11 @@ public class TkmsMariaDao extends TkmsDao {
   }
 
   @Override
+  protected String getSelectWithOffsetSql(TkmsShardPartition shardPartition) {
+    return "select id, message from " + getTableName(shardPartition) + " use index (PRIMARY) where id >= ? order by id limit ? offset ?";
+  }
+
+  @Override
   protected String getHasMessagesBeforeIdSql(TkmsShardPartition shardPartition) {
     return "select 1 from " + getTableName(shardPartition) + " use index(PRIMARY) where id < ? limit 1";
   }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsMariaDao.java
@@ -207,6 +207,16 @@ public class TkmsMariaDao extends TkmsDao {
   }
 
   @Override
+  protected String getMinMessageIdSql(TkmsShardPartition shardPartition) {
+    return "select min(id) from " + getTableName(shardPartition) + " use index(PRIMARY)";
+  }
+
+  @Override
+  protected String getMaxMessageIdSql(TkmsShardPartition shardPartition) {
+    return "select max(id) from " + getTableName(shardPartition) + " use index(PRIMARY)";
+  }
+
+  @Override
   protected String getExplainClause() {
     return "EXPLAIN FORMAT=JSON";
   }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
@@ -47,6 +47,16 @@ public class TkmsPostgresDao extends TkmsDao {
   }
 
   @Override
+  protected String getMinMessageIdSql(TkmsShardPartition shardPartition) {
+    return "select /*+ IndexOnlyScan(om) */ min(id) from " + getTableName(shardPartition) + " om";
+  }
+
+  @Override
+  protected String getMaxMessageIdSql(TkmsShardPartition shardPartition) {
+    return "select /*+ IndexOnlyScan(om) */ max(id) from " + getTableName(shardPartition) + " om";
+  }
+
+  @Override
   protected String getExplainClause() {
     return "EXPLAIN";
   }

--- a/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
+++ b/tw-tkms-starter/src/main/java/com/transferwise/kafka/tkms/dao/TkmsPostgresDao.java
@@ -37,6 +37,11 @@ public class TkmsPostgresDao extends TkmsDao {
   }
 
   @Override
+  protected String getSelectWithOffsetSql(TkmsShardPartition shardPartition) {
+    return "select /*+ IndexScan(om) */ id, message from " + getTableName(shardPartition) + " om where id >= ? order by id limit ? offset ?";
+  }
+
+  @Override
   protected String getHasMessagesBeforeIdSql(TkmsShardPartition shardPartition) {
     return "select /*+ IndexOnlyScan(om)  */ 1 from " + getTableName(shardPartition) + " om where id < ? order by id desc limit 1";
   }

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/FaultInjectedTkmsDao.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/FaultInjectedTkmsDao.java
@@ -57,6 +57,11 @@ public class FaultInjectedTkmsDao implements ITkmsDao {
   }
 
   @Override
+  public List<MessageRecord> getMessages(TkmsShardPartition shardPartition, long earliestMessageId, int limit, int offset) {
+    return delegate.getMessages(shardPartition, earliestMessageId, limit, offset);
+  }
+
+  @Override
   public void deleteMessages(TkmsShardPartition shardPartition, List<Long> records) {
     if (deleteMessagesFails) {
       throw new IllegalStateException("Delete messages has a bad day.");

--- a/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/FaultInjectedTkmsDao.java
+++ b/tw-tkms-starter/src/test/java/com/transferwise/kafka/tkms/dao/FaultInjectedTkmsDao.java
@@ -86,6 +86,16 @@ public class FaultInjectedTkmsDao implements ITkmsDao {
   }
 
   @Override
+  public Long getMinMessageId(TkmsShardPartition shardPartition) {
+    return delegate.getMinMessageId(shardPartition);
+  }
+
+  @Override
+  public Long getMaxMessageId(TkmsShardPartition shardPartition) {
+    return delegate.getMaxMessageId(shardPartition);
+  }
+
+  @Override
   public void validateDatabase() {
     delegate.validateDatabase();
   }

--- a/tw-tkms-starter/src/test/resources/application.yml
+++ b/tw-tkms-starter/src/test/resources/application.yml
@@ -31,6 +31,7 @@ tw-tkms:
   polling-interval: 5ms
   shards-count: 3
   insert-batch-size: 2
+  poller-parallelism: 2
   topics:
     - TestTopic
   kafka:


### PR DESCRIPTION
## Context
To speeded up message pooling when out_box accumulated huge lag introduced parallelism to message pooling process
This is related to incident with capability-hub  https://wise.enterprise.slack.com/archives/C0A0JNC8MTJ
By default processing does not change if poller-parallelism property is not configured 

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
